### PR TITLE
fix: change design padding

### DIFF
--- a/SickSangHae/Application/Assets.xcassets/Gray200.colorset/Contents.json
+++ b/SickSangHae/Application/Assets.xcassets/Gray200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDE",
+          "green" : "0xD6",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SickSangHae/Application/Assets.xcassets/PrimaryGB.colorset/Contents.json
+++ b/SickSangHae/Application/Assets.xcassets/PrimaryGB.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBD",
+          "green" : "0xB2",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SickSangHae/View/TabBarView.swift
+++ b/SickSangHae/View/TabBarView.swift
@@ -54,18 +54,17 @@ struct CustomTabView: View {
                     ZStack{
                         Rectangle()
                             .fill(LinearGradient(gradient: Gradient(colors: [Color("PrimaryG"), Color("PrimaryB")]), startPoint: .leading, endPoint: .trailing))
-                            .frame(width: screenWidth, height: 60.adjusted)
+                            .frame(width: screenWidth, height: 55.adjusted)
                             .foregroundColor(.blueGrayColor)
                             .padding(.bottom, 12.adjusted)
-                            .cornerRadius(12.adjusted)
+                            .cornerRadius(15.adjusted)
                             .padding(.bottom, -12.adjusted)
 
                         HStack{
                             Image(systemName: "camera.viewfinder")
-                                .font(.system(size: 20.adjusted))
                             Text("영수증 스캔하기")
-                                .font(.system(size: 17.adjusted))
                         }
+                        .font(.system(size: 17.adjusted).weight(.semibold))
                         .foregroundColor(.white)
                     }
                 }
@@ -74,89 +73,92 @@ struct CustomTabView: View {
 
             HStack {
                 Spacer()
-                    .frame(width: 10.adjusted)
+                    .frame(width: 12.adjusted)
                 Rectangle()
-                    .frame(width: 80.adjusted, height: 80.adjusted)
+                    .frame(width: 48.adjusted, height: 49.adjusted)
                     .foregroundColor(.clear)
                     .overlay(
                         Button {
                             selectedTab = .MainView
                         } label: {
                             VStack{
-                                Image(systemName: selectedTab == .MainView ? "bag.fill" : "bag")
+                                Image(systemName: "refrigerator.fill")
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
-                                    .frame(width: 25)
-                                Text("나의 냉장고")
-                                    .font(.system(size: 14.adjusted))
+                                    .frame(width: 24)
+                                Text("냉장고")
+                                    .font(.system(size: 11.adjusted))
                             }
                             .foregroundColor(selectedTab == .MainView ? .mint : .gray)
                         }
                     )
 
                 Spacer()
+                    .frame(width: 50.adjusted)
 
                 Rectangle()
-                    .frame(width: 80.adjusted, height: 80.adjusted)
+                    .frame(width: 48.adjusted, height: 49.adjusted)
                     .foregroundColor(.clear)
                     .overlay(
                 Button {
                     selectedTab = .ChartView
                 } label: {
                     VStack{
-                        Image(systemName: "chart.bar.xaxis")
+                        Image(systemName: "chart.pie.fill")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 25)
+                            .frame(width: 24)
                         Text("통계")
-                            .font(.system(size: 14.adjusted))
+                            .font(.system(size: 11.adjusted))
                         }
                         .foregroundColor(selectedTab == .ChartView ? .mint : .gray)
                     }
                 )
                 Spacer()
+                    .frame(width: 50.adjusted)
 
                 Rectangle()
-                    .frame(width: 80.adjusted, height: 80.adjusted)
+                    .frame(width: 48.adjusted, height: 49.adjusted)
                     .foregroundColor(.clear)
                     .overlay(
                 Button {
                     selectedTab = .HistoryView
                 } label: {
                     VStack{
-                        Image(systemName: selectedTab == .HistoryView ? "newspaper.fill" : "newspaper")
+                        Image(systemName: "archivebox.fill")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 25)
+                            .frame(width: 24)
                         Text("보관함")
-                            .font(.system(size: 14.adjusted))
+                            .font(.system(size: 11.adjusted))
                         }
                         .foregroundColor(selectedTab == .HistoryView ? .mint : .gray)
                     }
                 )
 
                 Spacer()
+                    .frame(width: 50.adjusted)
 
                 Rectangle()
-                    .frame(width: 80.adjusted, height: 80.adjusted)
+                    .frame(width: 48.adjusted, height: 49.adjusted)
                     .foregroundColor(.clear)
                     .overlay(
                 Button {
                     selectedTab = .SettingView
                 } label: {
                     VStack{
-                        Image(systemName: selectedTab == .SettingView ? "circle.fill" : "circle")
+                        Image(systemName: "gearshape.fill")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 25)
+                            .frame(width: 24)
                         Text("설정")
-                            .font(.system(size: 14.adjusted))
+                            .font(.system(size: 11.adjusted))
                         }
                         .foregroundColor(selectedTab == .SettingView ? .mint : .gray)
                     }
                 )
                 Spacer()
-                    .frame(width: 10.adjusted)
+                    .frame(width: 12.adjusted)
             }
         }
         .frame(height: 90.adjusted)

--- a/SickSangHae/View/TabBarView.swift
+++ b/SickSangHae/View/TabBarView.swift
@@ -89,7 +89,7 @@ struct CustomTabView: View {
                                 Text("냉장고")
                                     .font(.system(size: 11.adjusted))
                             }
-                            .foregroundColor(selectedTab == .MainView ? .mint : .gray)
+                            .foregroundColor(selectedTab == .MainView ? Color("PrimaryGB") : Color("Gray200"))
                         }
                     )
 
@@ -111,7 +111,7 @@ struct CustomTabView: View {
                         Text("통계")
                             .font(.system(size: 11.adjusted))
                         }
-                        .foregroundColor(selectedTab == .ChartView ? .mint : .gray)
+                        .foregroundColor(selectedTab == .ChartView ? Color("PrimaryGB") : Color("Gray200"))
                     }
                 )
                 Spacer()
@@ -132,7 +132,7 @@ struct CustomTabView: View {
                         Text("보관함")
                             .font(.system(size: 11.adjusted))
                         }
-                        .foregroundColor(selectedTab == .HistoryView ? .mint : .gray)
+                        .foregroundColor(selectedTab == .HistoryView ? Color("PrimaryGB") : Color("Gray200"))
                     }
                 )
 
@@ -154,7 +154,7 @@ struct CustomTabView: View {
                         Text("설정")
                             .font(.system(size: 11.adjusted))
                         }
-                        .foregroundColor(selectedTab == .SettingView ? .mint : .gray)
+                        .foregroundColor(selectedTab == .SettingView ? Color("PrimaryGB") : Color("Gray200"))
                     }
                 )
                 Spacer()


### PR DESCRIPTION
fix: change design padding

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #14 

👷 **작업한 내용**
- Custom Tab Bar 디자인 패딩값 변경

## 🚨 참고 사항
- figma를 참고했어요.

## 📸 스크린샷\
|기능|스크린샷|
|:--:|:--:|
|영수증 스캔하기 버튼|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/d87cf083-8aa9-4ff7-a96f-10b53a14d716 width: 40%">
|탭바 간격 및 패딩|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/424ae113-84d0-462a-ba74-c8a11f5cd399 width: 40%">

## 📟 관련 이슈
- Resolved: #
