### PR TITLE
 #14/LongTermList-2 

### DIFF
--- a/SickSangHae/View/Reusable/LongTermList.swift
+++ b/SickSangHae/View/Reusable/LongTermList.swift
@@ -8,66 +8,72 @@
 import SwiftUI
 
 struct LongTermList: View {
-    let testLists = ["계란 30구","모둠쌈","요플레","요플레","모둠쌈","라면","양파","계란","모둠쌈","요플레","모둠쌈","모둠쌈","계란","요플레","모둠쌈","요플레"]
 
     var body: some View {
-        NavigationStack {
+
             List {
-                ForEach(testLists, id: \.self) { testList in
-
-                    HStack{
-
-                        // 이 부분 빈 문자열이 없으면 이미지 밑에 구분선이 왜 없어질까요?
-                        Text("")
-                            .foregroundColor(.clear)
-
-                        Image(systemName: "circle.fill")
-                            .resizable()
-                            .foregroundColor(Color("Gray200"))
-                            .frame(width: 36.adjusted, height: 36.adjusted)
-
-                        Text(testList)
-                            .foregroundColor(Color("Gray900"))
-                            .font(.system(size: 17.adjusted).weight(.semibold))
-                        //                            .font(.custom("Pretendard-Bold", size: 20)) // Pretendard Bold 폰트 적용
-
-                        Spacer()
-
-                        Text("구매한지 x일")
-                            .foregroundColor(Color("Gray900"))
-                            .font(.system(size: 14.adjusted).weight(.semibold))
-                    }
-
-                }
-                .padding(.vertical, 16.adjusted)
+                ListTitle()
+                    .padding([.top, .bottom], 27.adjusted)
+                ListContents()
+                    .padding(.vertical, 16.adjusted)
             }
             .listStyle(.plain)
-            .padding(.top, 27.adjusted)
-            .navigationBarItems(leading: leadingText, trailing: trailingButton)
-        }
-
     }
+}
 
-    var leadingText: some View {
+struct ListTitle: View{
+    var body: some View{
+        HStack{
             Text("천천히 먹어도 돼요")
-            .foregroundColor(Color("Gray900"))
-            .font(.system(size: 20.adjusted).weight(.bold))
-            .padding(.top, 27.adjusted)
-        }
+                .foregroundColor(Color("Gray900"))
+                .font(.system(size: 20.adjusted))
 
-    var trailingButton: some View {
-        Button(action: {
-            // Your action for the trailing button
-        }) {
-            Text("최신순")
-            Image(systemName: "arrow.up.arrow.down")
+            Spacer()
+
+            Button{
+
+            } label: {
+
+                HStack(spacing: 2.adjusted){
+                    Text("최신순")
+                    Image(systemName: "arrow.up.arrow.down")
+                }
+            }
+            .foregroundColor(Color("Gray600"))
+            .font(.system(size: 14.adjusted))
         }
-        .foregroundColor(Color("Gray600"))
-        .font(.system(size: 14.adjusted).weight(.semibold))
-        .padding(.top, 27.adjusted)
     }
+}
 
+struct ListContents: View{
+    let testLists = ["계란 30구","모둠쌈","요플레","요플레","모둠쌈","라면","양파","계란","모둠쌈","요플레","모둠쌈","모둠쌈","계란","요플레","모둠쌈","요플레"]
+    var body: some View{
+        ForEach(testLists, id: \.self) { testList in
+            HStack{
 
+                // 이 부분 빈 문자열이 없으면 이미지 밑에 구분선이 왜 없어질까요?
+                Text("")
+                    .foregroundColor(.clear)
+
+                Image(systemName: "circle.fill")
+                    .resizable()
+                    .foregroundColor(Color("Gray200"))
+                    .frame(width: 36.adjusted, height: 36.adjusted)
+
+                Text(testList)
+                    .foregroundColor(Color("Gray900"))
+                    .font(.system(size: 17.adjusted).weight(.semibold))
+                //                            .font(.custom("Pretendard-Bold", size: 20)) // Pretendard Bold 폰트 적용
+
+                Spacer()
+
+                Text("구매한지 x일")
+                    .foregroundColor(Color("Gray900"))
+                    .font(.system(size: 14.adjusted).weight(.semibold))
+            }
+
+        }
+    }
 }
 
 struct LongTermList_Previews: PreviewProvider {

--- a/SickSangHae/View/Reusable/LongTermList.swift
+++ b/SickSangHae/View/Reusable/LongTermList.swift
@@ -8,21 +8,20 @@
 import SwiftUI
 
 struct LongTermList: View {
+    let testLists = ["계란 30구","모둠쌈","요플레","요플레","모둠쌈","라면","양파","계란","모둠쌈","요플레","모둠쌈","모둠쌈","계란","요플레","모둠쌈","요플레"]
 
     var body: some View {
 
-            List {
-                ListTitle()
-                    .padding([.top, .bottom], 27.adjusted)
-                ListContents()
-                    .padding(.vertical, 16.adjusted)
-            }
-            .listStyle(.plain)
+        List {
+            ListTitle
+                .padding([.top, .bottom], 27.adjusted)
+            ListContents
+                .padding(.vertical, 16.adjusted)
+        }
+        .listStyle(.plain)
     }
-}
 
-struct ListTitle: View{
-    var body: some View{
+    private var ListTitle: some View {
         HStack{
             Text("천천히 먹어도 돼요")
                 .foregroundColor(Color("Gray900"))
@@ -43,11 +42,8 @@ struct ListTitle: View{
             .font(.system(size: 14.adjusted))
         }
     }
-}
 
-struct ListContents: View{
-    let testLists = ["계란 30구","모둠쌈","요플레","요플레","모둠쌈","라면","양파","계란","모둠쌈","요플레","모둠쌈","모둠쌈","계란","요플레","모둠쌈","요플레"]
-    var body: some View{
+    private var ListContents: some View{
         ForEach(testLists, id: \.self) { testList in
             HStack{
 
@@ -75,6 +71,7 @@ struct ListContents: View{
         }
     }
 }
+
 
 struct LongTermList_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #14 

👷 **작업한 내용**
- navigationStack을 사용해서 navigationBarItems을 사용하던 기존 LongTermList에서 custom List로 변경 했어요

## 🚨 참고 사항
- 드래그했을때 navigationTitle이 같이 드래그 되어야 해서 custom List로 변경했어요.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/570549af-51ae-4d06-99c5-dd506f843fba" width = 40%>


## 📟 관련 이슈
- Resolved: #
