### PR TITLE
#14/LongTermList-3 Design 수정

### DIFF
--- a/SickSangHae/View/Reusable/LongTermList.swift
+++ b/SickSangHae/View/Reusable/LongTermList.swift
@@ -12,11 +12,9 @@ struct LongTermList: View {
 
     var body: some View {
 
-        List {
+        ScrollView {
             ListTitle
-                .padding([.top, .bottom], 27.adjusted)
             ListContents
-                .padding(.vertical, 16.adjusted)
         }
         .listStyle(.plain)
     }
@@ -25,7 +23,7 @@ struct LongTermList: View {
         HStack{
             Text("천천히 먹어도 돼요")
                 .foregroundColor(Color("Gray900"))
-                .font(.system(size: 20.adjusted))
+                .font(.system(size: 20.adjusted).weight(.bold))
 
             Spacer()
 
@@ -35,17 +33,21 @@ struct LongTermList: View {
 
                 HStack(spacing: 2.adjusted){
                     Text("최신순")
+                        .foregroundColor(Color("Gray600"))
                     Image(systemName: "arrow.up.arrow.down")
                 }
             }
             .foregroundColor(Color("Gray600"))
             .font(.system(size: 14.adjusted))
+            .padding(.trailing, 20.adjusted)
         }
+        .padding([.top, .bottom], 17.adjusted)
+        .padding([.leading], 20.adjusted)
     }
 
     private var ListContents: some View{
         ForEach(testLists, id: \.self) { testList in
-            HStack{
+            HStack(spacing: 0){
 
                 // 이 부분 빈 문자열이 없으면 이미지 밑에 구분선이 왜 없어질까요?
                 Text("")
@@ -56,19 +58,27 @@ struct LongTermList: View {
                     .foregroundColor(Color("Gray200"))
                     .frame(width: 36.adjusted, height: 36.adjusted)
 
+                Spacer()
+                    .frame(width: 12.adjusted)
+
                 Text(testList)
                     .foregroundColor(Color("Gray900"))
                     .font(.system(size: 17.adjusted).weight(.semibold))
-                //                            .font(.custom("Pretendard-Bold", size: 20)) // Pretendard Bold 폰트 적용
 
                 Spacer()
 
                 Text("구매한지 x일")
                     .foregroundColor(Color("Gray900"))
                     .font(.system(size: 14.adjusted).weight(.semibold))
+                    .padding(.trailing, 20.adjusted)
             }
+            .padding([.top, .bottom], 8.adjusted)
 
+            Divider()
+                .overlay(Color("Gray100"))
+                .opacity(testList == data.last ? 0 : 1)
         }
+        .padding([.leading], 20.adjusted)
     }
 }
 


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #14 

👷 **작업한 내용**
- MainView에 들어가는 LongTermList의 디자인 수정사항 반영

## 🚨 참고 사항
- BasicList와 패딩값을 동일하게 적용함

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|TabBarView에서 보이는 LongTermList|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/2981e5e0-cd09-4419-aa97-d6c683a4d772" width = 40%>
|TabBarView에서 보이는 BasicList|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/249acd8b-6a2c-4d41-8910-93306c95ecd8" width = 40%>

## 📟 관련 이슈
- Resolved: #
