### PR TITLE
#14/fix main view ui

### DIFF
--- a/SickSangHae/View/MainView.swift
+++ b/SickSangHae/View/MainView.swift
@@ -102,7 +102,9 @@ struct SearchBar: View {
                         }
                     }
                 
-                if !text.isEmpty {
+                if text.isEmpty {
+                    EmptyView()
+                } else {
                     Button(action: {
                         self.text = ""
                     }) {
@@ -113,8 +115,6 @@ struct SearchBar: View {
                                 .foregroundColor(Color("Gray200"))
                         }
                     }
-                } else {
-                    EmptyView()
                 }
             }
             .padding(.leading, 4)

--- a/SickSangHae/View/MainView.swift
+++ b/SickSangHae/View/MainView.swift
@@ -23,37 +23,38 @@ struct MainView: View {
 
     var body: some View {
 
-        VStack(alignment: .leading){
+        VStack(alignment: .leading, spacing: 0){
             Spacer()
-                .frame(height: 32.adjusted)
+                .frame(height: 32)
 
             HStack(alignment: .top){
                 Button{
                     selectedTopTabBar = .basic
                 } label: {
                     Text("일반 보관")
-                        .font(.system(size: 28.adjusted).weight(.bold))
+                        .font(.system(size: 28, weight: .bold))
                         .foregroundColor(selectedTopTabBar == .basic ? Color("PrimaryGB") : Color("Gray200"))
                 }
 
                 Spacer()
-                    .frame(width: CGFloat(15).adjusted)
+                    .frame(width: 15)
 
                 Button{
                     selectedTopTabBar = .longterm
                 } label: {
                     Text("장기 보관")
-                        .font(.system(size: 28.adjusted).weight(.bold))
+                        .font(.system(size: 28).weight(.bold))
                         .foregroundColor(selectedTopTabBar == .longterm ? Color("PrimaryGB") : Color("Gray200"))
                 }
             }
             .padding(.horizontal, 20)
 
             Spacer()
-                .frame(height: 30.adjusted)
+                .frame(height: 20)
 
             SearchBar(text: $text)
                 .padding(.horizontal, 20)
+                .padding(.bottom, 10)
 
             switch selectedTopTabBar {
             case .basic:
@@ -61,8 +62,6 @@ struct MainView: View {
             case .longterm:
                 LongTermList()
             }
-
-            Spacer()
             
         }
 
@@ -77,18 +76,53 @@ struct SearchBar: View {
     @FocusState var isInputActive: Bool
 
     var body: some View {
-        TextField("Enter your name", text: $text)
-            .textFieldStyle(.roundedBorder)
-                            .focused($isInputActive)
-                            .toolbar {
-                                ToolbarItemGroup(placement: .keyboard) {
-                                    Spacer()
-
-                                    Button("Done") {
-                                        isInputActive = false
-                                    }
-                                }
+        HStack {
+            Spacer()
+                .frame(width: 12)
+            
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(Color("Gray200"))
+            
+            ZStack(alignment: .leading) {
+                if text.isEmpty {
+                    Text("식재료 검색")
+                        .foregroundColor(Color("Gray200"))
+                } else {
+                    EmptyView()
+                }
+                TextField("", text: $text)
+                    .focused($isInputActive)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            
+                            Button("완료") {
+                                isInputActive = false
                             }
+                        }
+                    }
+                
+                if !text.isEmpty {
+                    Button(action: {
+                        self.text = ""
+                    }) {
+                        HStack {
+                            Spacer()
+                            
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(Color("Gray200"))
+                        }
+                    }
+                } else {
+                    EmptyView()
+                }
+            }
+            .padding(.leading, 4)
+            .padding(.trailing, 12)
+        }
+        .frame(height: 42)
+        .background(Color("Gray50"))
+        .cornerRadius(10)
     }
 }
 
@@ -98,3 +132,4 @@ struct MainView_Previews: PreviewProvider {
     MainView()
   }
 }
+


### PR DESCRIPTION
#14/implementMainView

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #14/fixMainViewUI

👷 **작업한 내용**
- MainVew의 searchBar를 피그마 디자인에 맞게 커스텀 작업.
- 일부 padding 및 frame값을 조정하여 iPhoneSE 또는 iPhone14ProMax에서도 동일한 UI로 보이게끔 수정.

## 🚨 참고 사항
- none

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|Custom SearchBar|<img width="475" alt="스크린샷 2023-07-24 오후 4 45 48" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/123388563/292053f0-fba4-46cd-8670-6dc19d074d5f">

## 📟 관련 이슈
- Resolved: #14 
