### PR TITLE
feature: implement center alert view

### DIFF
--- a/SickSangHae/View/Reusable/CenterAlertView.swift
+++ b/SickSangHae/View/Reusable/CenterAlertView.swift
@@ -8,11 +8,15 @@
 import SwiftUI
 
 struct CenterAlertView: View {
+    
+    let titleMessage: String
+    let bodyMessage: String
+    let actionButtonMessage: String
+    
     var body: some View {
         ZStack {
             Color.black.opacity(0.4)
                 .edgesIgnoringSafeArea(.all)
-            
             centerAlert
         }
     } //body닫기
@@ -37,14 +41,14 @@ struct CenterAlertView: View {
     
     var centerAlertText: some View {
         VStack(spacing: 0) {
-            Text("제목")
+            Text(titleMessage)
                 .font(.system(size: 20, weight: .semibold))
                 .foregroundColor(Color("Gray900"))
                 .frame(width: 240, height: 20)
                 .multilineTextAlignment(.center)
                 .padding(.bottom, 16)
             
-            Text("본문 경고 메시지")
+            Text("진짜로 \(bodyMessage)를 \(actionButtonMessage)하시겠습니까?")
                 .font(.system(size: 17, weight: .medium))
                 .foregroundColor(Color("Gray800"))
                 .frame(width: 240, height: 17)
@@ -81,7 +85,7 @@ struct CenterAlertView: View {
                     RoundedRectangle(cornerRadius: 8)
                         .frame(width: 125, height: 45)
                         .foregroundColor(Color("PointR"))
-                    Text("네, OO할래요")
+                    Text("네, \(actionButtonMessage)할래요")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(.white)
                 }
@@ -92,6 +96,6 @@ struct CenterAlertView: View {
 
 struct CenterAlertView_Previews: PreviewProvider {
     static var previews: some View {
-        CenterAlertView()
+        CenterAlertView(titleMessage: "제목", bodyMessage: "항목", actionButtonMessage: "취소")
     }
 }

--- a/SickSangHae/View/Reusable/CenterAlertView.swift
+++ b/SickSangHae/View/Reusable/CenterAlertView.swift
@@ -9,9 +9,86 @@ import SwiftUI
 
 struct CenterAlertView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+        ZStack {
+            Color.black.opacity(0.4)
+                .edgesIgnoringSafeArea(.all)
+            
+            centerAlert
+        }
+    } //body닫기
+    
+    
+    var centerAlert: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .stroke(.white, lineWidth: 2)
+            .frame(width: 300, height: 170)
+            .background(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .opacity(0.6)
+            .overlay(
+                VStack {
+                    centerAlertText
+                        .padding(.top, 20)
+                    centerAlertButton
+                        .padding(.bottom, 20)
+                }
+            )
+    } //backgroundRectangle닫기
+    
+    var centerAlertText: some View {
+        VStack(spacing: 0) {
+            Text("제목")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(Color("Gray900"))
+                .frame(width: 240, height: 20)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 16)
+            
+            Text("본문 경고 메시지")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundColor(Color("Gray800"))
+                .frame(width: 240, height: 17)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 18)
+        }
+    } //centerAlertText닫기
+    
+    var centerAlertButton: some View {
+        HStack {
+            Button(action: {
+                // showCenterAlert = false
+            }, label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .frame(width: 125, height: 45)
+                        .foregroundColor(Color("Gray100"))
+                    Text("아니오")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(Color("Gray600"))
+                }
+            })
+            
+            Spacer()
+                .frame(width: 10)
+            
+            Button(action: {
+                /*
+                 deleteItem
+                 showCenterAlert = false
+                 */
+            }, label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .frame(width: 125, height: 45)
+                        .foregroundColor(Color("PointR"))
+                    Text("네, OO할래요")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+            })
+        } //HStack닫기
+    } //centerAlertButton닫기
+} //struct닫기
 
 struct CenterAlertView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
#60/implementCenterAlertView

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #60 

👷 **작업한 내용**
- CenterAlertView의 UI 작업

## 🚨 참고 사항
- 알럿창 background의 glassy 반투명 효과 구현 연기
- 추후 CRUD진행하면서 버튼 로직에 삭제 관련 로직 추가 필요
- CenterAlertView 사용 case
    - UpdateItemView에서 식료품 등록 도중 창을 닫을 때
    - EditItemDetailView에서 식료품 항목을 완전 삭제할 때

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img width="374" alt="스크린샷 2023-07-26 오전 12 29 10" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/123388563/a3f43cb1-f632-415b-a197-d68ab0e09932">
