### PR TITLE
#17/edit item detail view

### DIFF
--- a/SickSangHae/View/EditItemDetailView.swift
+++ b/SickSangHae/View/EditItemDetailView.swift
@@ -30,7 +30,7 @@ struct EditItemDetailView: View {
         VStack {
             topNaviBar
             ScrollView {
-                iconEdit
+                editIconButton
                 InfoEditField(nameText: $nameText, wonText: $wonText)
             }
             deleteButton
@@ -69,7 +69,7 @@ struct EditItemDetailView: View {
         .padding(.top, 10)
     }
     
-    var iconEdit: some View {
+    var editIconButton: some View {
         ZStack(alignment: .bottomTrailing) {
             //추후 Custom Item Icon으로 대체
             Circle()

--- a/SickSangHae/View/EditItemDetailView.swift
+++ b/SickSangHae/View/EditItemDetailView.swift
@@ -7,11 +7,23 @@
 
 import SwiftUI
 
+extension View {
+    func endTextEditing() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+    }
+}
+
 struct EditItemDetailView: View {
     
     @Binding var isShowingEditView: Bool
     
+    @State private var isShowingIconView = false
+    
     @State var nameText: String = ""
+    @State var dateText: String = ""
     @State var wonText: String = ""
     
     var body: some View {
@@ -20,11 +32,14 @@ struct EditItemDetailView: View {
             ScrollView {
                 iconEdit
                 InfoEditField(nameText: $nameText, wonText: $wonText)
-                Spacer()
             }
             deleteButton
         }
         .padding(.horizontal, 20.adjusted)
+        .ignoresSafeArea(.keyboard)
+        .onTapGesture {
+            self.endTextEditing()
+        }
     }
     
     var topNaviBar: some View {
@@ -46,8 +61,9 @@ struct EditItemDetailView: View {
                 }, label: {
                     Text("완료")
                         .bold()
-                        .foregroundColor(.black)
                 })
+                .disabled(nameText.isEmpty)
+                .disabled(nameText == nameText && dateText == dateText && wonText == wonText)
             }
         }
         .padding(.top, 10)
@@ -61,7 +77,7 @@ struct EditItemDetailView: View {
                 .frame(width: 110, height: 110)
             
             Button(action: {
-                
+                self.isShowingIconView.toggle()
             }, label: {
                 ZStack {
                     Circle()
@@ -76,6 +92,9 @@ struct EditItemDetailView: View {
                         )
                 }
             })
+            .sheet(isPresented: self.$isShowingIconView) {
+                EditIconDetailView()
+            }
         }
         .padding(.vertical, 20.adjusted)
     }
@@ -110,14 +129,13 @@ struct InfoEditField: View {
     @State private var selectedDate = Date()
     @State private var showingDatePicker = false
     
-    var formattedDate: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy년 MM월 dd일"
-        return formatter.string(from: selectedDate)
+    var body: some View {
+        nameField
+        dateField
+        wonField
     }
     
-    var body: some View {
-        
+    var nameField: some View {
         VStack(alignment: .leading) {
             Text("품목명")
                 .font(.system(size: 14, weight: .medium))
@@ -139,7 +157,7 @@ struct InfoEditField: View {
                             Spacer()
                             
                             Button("완료") {
-                                isInputActive = false
+                                isInputActive = true
                             }
                         }
                     }
@@ -164,8 +182,10 @@ struct InfoEditField: View {
             .background(Color("Gray50"))
             .cornerRadius(8)
         }
-        .padding(.bottom, 20)
-        
+        .padding(.bottom, 10)
+    }
+    
+    var dateField: some View {
         VStack(alignment: .leading) {
             Text("구매일")
                 .font(.system(size: 14, weight: .medium))
@@ -199,8 +219,10 @@ struct InfoEditField: View {
             .background(Color("Gray50"))
             .cornerRadius(8)
         }
-        .padding(.bottom, 20)
-        
+        .padding(.bottom, 10)
+    }
+    
+    var wonField: some View {
         VStack(alignment: .leading) {
             Text("구매금액")
                 .font(.system(size: 14, weight: .medium))
@@ -248,7 +270,13 @@ struct InfoEditField: View {
             .background(Color("Gray50"))
             .cornerRadius(8)
         }
-        .padding(.bottom, 20)
+        .padding(.bottom, 10)
+    }
+    
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        return formatter.string(from: selectedDate)
     }
 }
 

--- a/SickSangHae/View/EditItemDetailView.swift
+++ b/SickSangHae/View/EditItemDetailView.swift
@@ -8,13 +8,252 @@
 import SwiftUI
 
 struct EditItemDetailView: View {
+    
+    @Binding var isShowingEditView: Bool
+    
+    @State var nameText: String = ""
+    @State var wonText: String = ""
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            topNaviBar
+            ScrollView {
+                iconEdit
+                InfoEditField(nameText: $nameText, wonText: $wonText)
+                Spacer()
+            }
+            deleteButton
+        }
+        .padding(.horizontal, 20.adjusted)
+    }
+    
+    var topNaviBar: some View {
+        ZStack {
+            Text("수정")
+                .bold()
+            HStack {
+                Button(action: {
+                    self.isShowingEditView.toggle()
+                }, label: {
+                    Text("취소")
+                        .bold()
+                        .foregroundColor(.black)
+                })
+                Spacer()
+                Button(action: {
+                    //변경된 텍스트 값을 ItemDetailView로 업데이트하는 로직
+                    self.isShowingEditView.toggle()
+                }, label: {
+                    Text("완료")
+                        .bold()
+                        .foregroundColor(.black)
+                })
+            }
+        }
+        .padding(.top, 10)
+    }
+    
+    var iconEdit: some View {
+        ZStack(alignment: .bottomTrailing) {
+            //추후 Custom Item Icon으로 대체
+            Circle()
+                .foregroundColor(Color("Gray200"))
+                .frame(width: 110, height: 110)
+            
+            Button(action: {
+                
+            }, label: {
+                ZStack {
+                    Circle()
+                        .foregroundColor(Color("Gray100"))
+                        .frame(width: 28, height: 28)
+                    Circle()
+                        .stroke(.white, lineWidth: 2)
+                        .frame(width: 28, height: 28)
+                        .overlay(
+                            Image(systemName: "pencil")
+                                .foregroundColor(.black)
+                        )
+                }
+            })
+        }
+        .padding(.vertical, 20.adjusted)
+    }
+    
+    var deleteButton: some View {
+        Button(action: {
+            
+        }, label: {
+            ZStack {
+                Rectangle()
+                    .cornerRadius(8)
+                    .frame(height: 60)
+                    .foregroundColor(Color("Gray100"))
+                Text("항목 삭제")
+                    .bold()
+                    .foregroundColor(.red)
+            }
+            .padding(.bottom, 20.adjusted)
+        })
+    }
+}
+
+
+struct InfoEditField: View {
+    
+    @Binding var nameText: String
+    @Binding var wonText: String
+    
+    @State private var isEditing = false
+    @FocusState var isInputActive: Bool
+    
+    @State private var selectedDate = Date()
+    @State private var showingDatePicker = false
+    
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        return formatter.string(from: selectedDate)
+    }
+    
+    var body: some View {
+        
+        VStack(alignment: .leading) {
+            Text("품목명")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(Color("Gray600"))
+            
+            ZStack(alignment: .leading) {
+                if nameText.isEmpty {
+                    Text("품목명은 필수에요")
+                        .bold()
+                        .foregroundColor(Color("Gray200"))
+                } else {
+                    EmptyView()
+                }
+                
+                TextField("", text: $nameText)
+                    .focused($isInputActive)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            
+                            Button("완료") {
+                                isInputActive = false
+                            }
+                        }
+                    }
+                
+                if nameText.isEmpty || !isInputActive {
+                    EmptyView()
+                } else {
+                    Button(action: {
+                        self.nameText = ""
+                    }, label: {
+                        HStack {
+                            Spacer()
+                            
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(Color("Gray200"))
+                        }
+                    })
+                }
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 60)
+            .background(Color("Gray50"))
+            .cornerRadius(8)
+        }
+        .padding(.bottom, 20)
+        
+        VStack(alignment: .leading) {
+            Text("구매일")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(Color("Gray600"))
+            
+            ZStack(alignment: .leading) {
+                Button(action: {
+                    showingDatePicker.toggle()
+                }, label: {
+                    HStack {
+                        Text(formattedDate)
+                            .bold()
+                            .foregroundColor(.black)
+                        
+                        Spacer()
+                    }
+                })
+                .sheet(isPresented: $showingDatePicker) {
+                    DatePicker("구매일자", selection: $selectedDate, in: ...Date(), displayedComponents: .date)
+                        .presentationDetents([.medium])
+                        .datePickerStyle(GraphicalDatePickerStyle())
+                        .padding(.horizontal, 10)
+                        .environment(\.locale, .init(identifier: "ko"))
+                        .onChange(of: selectedDate) { _ in
+                            showingDatePicker = false
+                        }
+                }
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 60)
+            .background(Color("Gray50"))
+            .cornerRadius(8)
+        }
+        .padding(.bottom, 20)
+        
+        VStack(alignment: .leading) {
+            Text("구매금액")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(Color("Gray600"))
+            
+            ZStack(alignment: .leading) {
+                if wonText.isEmpty {
+                    Text("얼마였나요?")
+                        .bold()
+                        .foregroundColor(Color("Gray200"))
+                } else {
+                    EmptyView()
+                }
+                
+                TextField("", text: $wonText)
+                    .focused($isInputActive)
+                    .keyboardType(.numberPad)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            
+                            Button("완료") {
+                                isInputActive = false
+                            }
+                        }
+                    }
+                
+                if wonText.isEmpty || !isInputActive {
+                    EmptyView()
+                } else {
+                    Button(action: {
+                        self.wonText = ""
+                    }, label: {
+                        HStack {
+                            Spacer()
+                            
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(Color("Gray200"))
+                        }
+                    })
+                }
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 60)
+            .background(Color("Gray50"))
+            .cornerRadius(8)
+        }
+        .padding(.bottom, 20)
     }
 }
 
 struct EditItemDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        EditItemDetailView()
+        EditItemDetailView(isShowingEditView: .constant(false))
     }
 }

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -18,67 +18,76 @@ struct ItemDetailView: View {
     var greenBlueGradient = Gradient(colors: [Color("PrimaryG"), Color("PrimaryB")])
     var notSelectedGradient = Gradient(colors: [Color("Gray200"), Color("Gray200")])
     var clearGradient = Gradient(colors: [.clear, .clear])
-    @State var needToEatASAP: selected = .unselected
     
+    @State var needToEatASAP: selected = .unselected
+    @State private var isShowingEditView = false
     
     var body: some View {
         
             VStack {
-                ScrollView {
-                    HStack {
-                        Image(systemName: "chevron.left")
-                            .resizable()
-                            .frame(width: 10.adjusted, height: 18.adjusted)
-                        Spacer()
-                        Text("계란 30구")
-                            .bold()
-                            .padding(.leading, 15.adjusted)
-                        Spacer()
+                HStack {
+                    Image(systemName: "chevron.left")
+                        .resizable()
+                        .frame(width: 10.adjusted, height: 18.adjusted)
+                    Spacer()
+                    Text("계란 30구")
+                        .bold()
+                        .padding(.leading, 15.adjusted)
+                    Spacer()
+                    Button(action: {
+                        self.isShowingEditView.toggle()
+                    }, label: {
                         Text("수정")
                             .bold()
+                            .foregroundColor(.black)
+                    })
+                    .fullScreenCover(isPresented: $isShowingEditView) {
+                        EditItemDetailView(isShowingEditView: $isShowingEditView)
                     }
-                    .padding(.horizontal, 20)
+                }
+                .padding(.top, 10)
+                
+                ScrollView {
                     
                     HStack {
-                        Circle()
-                            .foregroundColor(Color("Gray200"))
-                            .frame(width: 80.adjusted)
-                        Text("계란 30구")
-                            .font(.title3)
-                            .bold()
-                            .padding(15)
-                    }
-                    .frame(width: 350.adjusted, alignment: .leading)
-                    .padding(.vertical, 25.adjusted)
-                    
-                    VStack(alignment: .leading) {
-                        Text("구매일")
-                            .font(.subheadline)
-                        ZStack(alignment: .leading) {
-                            Rectangle()
-                                .cornerRadius(8)
-                                .frame(width: 350.adjusted, height: 60.adjusted)
-                                .foregroundColor(Color("Gray50"))
+                        VStack(alignment: .leading, spacing: 0) {
+                            
+                            HStack {
+                                Circle()
+                                    .foregroundColor(Color("Gray200"))
+                                    .frame(width: 80)
+                                Text("계란 30구")
+                                    .font(.system(size: 22, weight: .bold))
+                                    .padding(.leading, 15)
+                            }
+                            .padding(.vertical, 30)
+                            
+                            Text("구매일")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(Color("Gray600"))
+                                .padding(.bottom, 12)
                             Text("2023년 7월 39일")
-                                .bold()
-                                .padding(.horizontal, 20.adjusted)
-                        }
-                        Text("구매금액")
-                            .font(.subheadline)
-                        ZStack(alignment: .leading) {
-                            Rectangle()
-                                .cornerRadius(8)
-                                .frame(width: 350.adjusted, height: 60.adjusted)
-                                .foregroundColor(Color("Gray50"))
+                                .font(.system(size: 20, weight: .bold))
+                                .padding(.bottom, 30)
+                            
+                            Text("구매금액")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(Color("Gray600"))
+                                .padding(.bottom, 12)
                             Text("9,800원")
-                                .bold()
-                                .padding(.horizontal, 20.adjusted)
+                                .font(.system(size: 20, weight: .bold))
+                                .padding(.bottom, 30)
                         }
+                        
+                        Spacer()
                     }
+                    .padding(.leading, 20.adjusted)
+                    
                     Rectangle()
-                        .frame(width: 390.adjusted ,height: 12.adjusted)
+                        .frame(width: screenWidth ,height: 12)
                         .foregroundColor(Color("Gray100"))
-                        .padding(.vertical, 30.adjusted)
+                        .padding(.top, 10)
+                        .padding(.bottom, 30)
                     // 식재료 정보와 냉장고 선택창과의 분리
                     
                     VStack(alignment: .leading) {
@@ -92,34 +101,57 @@ struct ItemDetailView: View {
                             .bold()
                             .padding(.vertical, 5)
                         VStack {
-                            Button(action: {needToEatASAP = .basic}) {
-                                Text(" ")
-                                    .frame(width: 10.adjusted, height: 10.adjusted)
-                                    .background(needToEatASAP == .basic ? greenBlueGradient : clearGradient)
-                                    .cornerRadius(100)
-                                    .padding(7)
-                                    .overlay(RoundedRectangle(cornerRadius: 100)
-                                        .stroke(LinearGradient(
-                                            gradient: needToEatASAP == .basic ? greenBlueGradient: notSelectedGradient,
+                            Button(action: {
+                                needToEatASAP = .basic
+                            }, label: {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .frame(height: 60)
+                                        .foregroundColor(Color("Gray50"))
+                                    
+                                    HStack {
+                                        ZStack {
+                                            Circle()
+                                                .stroke(
+                                                    LinearGradient(
+                                                        gradient: needToEatASAP == .basic ? greenBlueGradient: notSelectedGradient,
+                                                        startPoint: .leading,
+                                                        endPoint: .trailing
+                                                    ),
+                                                    lineWidth: 2
+                                                )
+                                                .frame(width: 20, height: 20)
+                                            Circle()
+                                                .fill(
+                                                    LinearGradient(
+                                                        gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                                                        startPoint: .leading,
+                                                        endPoint: .trailing
+                                                    )
+                                                )
+                                                .frame(width: 8, height: 8)
+                                        }
+                                        .padding(.leading, 20)
+                                        
+                                        Text("기본")
+                                            .font(.system(size: 17, weight: .semibold))
+                                            .padding(.leading, 5)
+                                            .foregroundColor(Color("Gray900"))
+                                        
+                                        Spacer()
+                                    }
+                                }
+                            })
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(
+                                        LinearGradient(
+                                            gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                                             startPoint: .leading,
                                             endPoint: .trailing
-                                        ), lineWidth: 3)
+                                        ),
+                                        lineWidth: 2
                                     )
-                                Text("기본")
-                                    .padding(.leading, 5.adjusted)
-                                    .foregroundColor(Color("Gray900"))
-                            }
-                            .padding(.horizontal, 20)
-                            .frame(width: 350.adjusted, height: 60.adjusted, alignment: .leading)
-                            .background(Color("Gray50"))
-                            .cornerRadius(15)
-                            .overlay(RoundedRectangle(cornerRadius: 15)
-                                .stroke(LinearGradient(
-                                    gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                ), lineWidth: 3)
-                                     
                             )
                             
                             Button(action: {needToEatASAP = .fastEat}) {
@@ -190,7 +222,7 @@ struct ItemDetailView: View {
                 }
             } // first VStack
             .padding(.horizontal, 20.adjusted)
-            
+        
         }
         
     struct ItemDetailView_Previews: PreviewProvider {

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -24,210 +24,293 @@ struct ItemDetailView: View {
     
     var body: some View {
         
-            VStack {
-                HStack {
-                    Image(systemName: "chevron.left")
-                        .resizable()
-                        .frame(width: 10.adjusted, height: 18.adjusted)
-                    Spacer()
-                    Text("계란 30구")
-                        .bold()
-                        .padding(.leading, 15.adjusted)
-                    Spacer()
-                    Button(action: {
-                        self.isShowingEditView.toggle()
-                    }, label: {
-                        Text("수정")
-                            .bold()
-                            .foregroundColor(.black)
-                    })
-                    .fullScreenCover(isPresented: $isShowingEditView) {
-                        EditItemDetailView(isShowingEditView: $isShowingEditView)
-                    }
-                }
-                .padding(.top, 10)
+        VStack {
+            topNaviBar
+            
+            ScrollView {
+                itemInfoSection
                 
-                ScrollView {
+                VStack(alignment: .leading) {
+                    Text("냉장고 선택하기")
+                        .font(.system(size: 20, weight: .bold))
+                        .font(.title2)
+                        .padding(.bottom, 2)
+                    
+                    Text("식료품의 특징에 맞게 선택해주세요.")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(Color("Gray600"))
+                    
+                    Text("일반")
+                        .font(.system(size: 17, weight: .bold))
+                        .padding(.top, 20)
+                        .padding(.bottom, 5)
+                    
+                    bacicRadioButton
+                    
+                    fastEatRadioButton
+                    
+                    Text("장기 보관")
+                        .font(.system(size: 17, weight: .bold))
+                        .padding(.top, 20)
+                        .padding(.bottom, 5)
+                    
+                    slowEatRadioButton
+                    
+                    Spacer()
+                    
+                } //VStack닫기
+                .padding(.horizontal, 20.adjusted)
+                .padding(.bottom, 40)
+            } //ScrollView닫기
+        } // VStack닫기
+    } //body닫기
+        
+    var topNaviBar: some View {
+        HStack {
+            Image(systemName: "chevron.left")
+                .resizable()
+                .frame(width: 10, height: 18)
+            
+            Spacer()
+            
+            Text("계란 30구")
+                .bold()
+                .padding(.leading, 15)
+            
+            Spacer()
+            
+            Button(action: {
+                self.isShowingEditView.toggle()
+            }, label: {
+                Text("수정")
+                    .bold()
+                    .foregroundColor(.black)
+            })
+            .fullScreenCover(isPresented: $isShowingEditView) {
+                EditItemDetailView(isShowingEditView: $isShowingEditView)
+            }
+        } //HStack닫기
+        .padding(.top, 10)
+        .padding(.horizontal, 20.adjusted)
+    }
+        
+    var itemInfoSection: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 0) {
                     
                     HStack {
-                        VStack(alignment: .leading, spacing: 0) {
-                            
-                            HStack {
-                                Circle()
-                                    .foregroundColor(Color("Gray200"))
-                                    .frame(width: 80)
-                                Text("계란 30구")
-                                    .font(.system(size: 22, weight: .bold))
-                                    .padding(.leading, 15)
-                            }
-                            .padding(.vertical, 30)
-                            
-                            Text("구매일")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundColor(Color("Gray600"))
-                                .padding(.bottom, 12)
-                            Text("2023년 7월 39일")
-                                .font(.system(size: 20, weight: .bold))
-                                .padding(.bottom, 30)
-                            
-                            Text("구매금액")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundColor(Color("Gray600"))
-                                .padding(.bottom, 12)
-                            Text("9,800원")
-                                .font(.system(size: 20, weight: .bold))
-                                .padding(.bottom, 30)
-                        }
+                        Circle()
+                            .foregroundColor(Color("Gray200"))
+                            .frame(width: 80)
                         
-                        Spacer()
+                        Text("계란 30구")
+                            .font(.system(size: 22, weight: .bold))
+                            .padding(.leading, 15)
                     }
-                    .padding(.leading, 20.adjusted)
+                    .padding(.vertical, 30)
                     
-                    Rectangle()
-                        .frame(width: screenWidth ,height: 12)
-                        .foregroundColor(Color("Gray100"))
-                        .padding(.top, 10)
+                    Text("구매일")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(Color("Gray600"))
+                        .padding(.bottom, 12)
+                    
+                    Text("2023년 7월 39일")
+                        .font(.system(size: 20, weight: .bold))
                         .padding(.bottom, 30)
-                    // 식재료 정보와 냉장고 선택창과의 분리
                     
-                    VStack(alignment: .leading) {
-                        Text("냉장고 선택하기")
-                            .bold()
-                            .font(.title2)
-                        Text("식료품의 특징에 맞게 선택해주세요.")
-                            .font(.subheadline)
-                            .padding(.top, 1)
-                        Text("일반")
-                            .bold()
-                            .padding(.vertical, 5)
-                        VStack {
-                            Button(action: {
-                                needToEatASAP = .basic
-                            }, label: {
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .frame(height: 60)
-                                        .foregroundColor(Color("Gray50"))
-                                    
-                                    HStack {
-                                        ZStack {
-                                            Circle()
-                                                .stroke(
-                                                    LinearGradient(
-                                                        gradient: needToEatASAP == .basic ? greenBlueGradient: notSelectedGradient,
-                                                        startPoint: .leading,
-                                                        endPoint: .trailing
-                                                    ),
-                                                    lineWidth: 2
-                                                )
-                                                .frame(width: 20, height: 20)
-                                            Circle()
-                                                .fill(
-                                                    LinearGradient(
-                                                        gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
-                                                        startPoint: .leading,
-                                                        endPoint: .trailing
-                                                    )
-                                                )
-                                                .frame(width: 8, height: 8)
-                                        }
-                                        .padding(.leading, 20)
-                                        
-                                        Text("기본")
-                                            .font(.system(size: 17, weight: .semibold))
-                                            .padding(.leading, 5)
-                                            .foregroundColor(Color("Gray900"))
-                                        
-                                        Spacer()
-                                    }
-                                }
-                            })
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(
-                                        LinearGradient(
-                                            gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
-                                            startPoint: .leading,
-                                            endPoint: .trailing
-                                        ),
-                                        lineWidth: 2
-                                    )
+                    Text("구매금액")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(Color("Gray600"))
+                        .padding(.bottom, 12)
+                    
+                    Text("9,800원")
+                        .font(.system(size: 20, weight: .bold))
+                        .padding(.bottom, 30)
+                }
+                
+                Spacer()
+            } //HStack닫기
+            .padding(.leading, 20.adjusted)
+            
+            Rectangle()
+                .frame(width: screenWidth ,height: 12)
+                .foregroundColor(Color("Gray100"))
+                .padding(.top, 10)
+                .padding(.bottom, 30)
+        }
+        
+    }
+    
+    var bacicRadioButton: some View {
+        Button(action: {
+            needToEatASAP = .basic
+        }, label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .frame(height: 60)
+                    .foregroundColor(Color("Gray50"))
+                
+                HStack {
+                    ZStack {
+                        Circle()
+                            .stroke(
+                                LinearGradient(
+                                    gradient: needToEatASAP == .basic ? greenBlueGradient: notSelectedGradient,
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ),
+                                lineWidth: 2
                             )
-                            
-                            Button(action: {needToEatASAP = .fastEat}) {
-                                Text(" ")
-                                    .frame(width: 10.adjusted, height: 10.adjusted)
-                                    .background(needToEatASAP == .fastEat ? greenBlueGradient : clearGradient)
-                                    .cornerRadius(100)
-                                    .padding(7)
-                                    .overlay(RoundedRectangle(cornerRadius: 100)
-                                        .stroke(LinearGradient(
-                                            gradient: needToEatASAP == .fastEat ? greenBlueGradient : notSelectedGradient,
-                                            startPoint: .leading,
-                                            endPoint: .trailing), lineWidth: 3)
-                                    )
-                                Text("빨리 먹어야 해요")
-                                    .padding(.leading, 5.adjusted)
-                                    .foregroundColor(Color("Gray900"))
-                            }
-                            .padding(.horizontal, 20)
-                            .frame(width: 350.adjusted, height: 60.adjusted, alignment: .leading)
-                            .background(Color("Gray50"))
-                            .cornerRadius(15)
-                            .overlay(RoundedRectangle(cornerRadius: 15)
-                                .stroke(LinearGradient(
+                            .frame(width: 20, height: 20)
+                        Circle()
+                            .fill(
+                                LinearGradient(
+                                    gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+                            .frame(width: 8, height: 8)
+                    }
+                    .padding(.leading, 20)
+                    
+                    Text("기본")
+                        .font(.system(size: 17, weight: .semibold))
+                        .padding(.leading, 5)
+                        .foregroundColor(Color("Gray900"))
+                    
+                    Spacer()
+                }
+            }
+        })
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    LinearGradient(
+                        gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    lineWidth: 2
+                )
+        )
+        
+    }
+    
+    var fastEatRadioButton: some View {
+        Button(action: {
+            needToEatASAP = .fastEat
+        }, label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .frame(height: 60)
+                    .foregroundColor(Color("Gray50"))
+                
+                HStack {
+                    ZStack {
+                        Circle()
+                            .stroke(
+                                LinearGradient(
+                                    gradient: needToEatASAP == .fastEat ? greenBlueGradient: notSelectedGradient,
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ),
+                                lineWidth: 2
+                            )
+                            .frame(width: 20, height: 20)
+                        Circle()
+                            .fill(
+                                LinearGradient(
                                     gradient: needToEatASAP == .fastEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                                     startPoint: .leading,
                                     endPoint: .trailing
-                                ), lineWidth: 3)
-                                     
+                                )
                             )
-                        }
-                        Text("장기 보관")
-                            .bold()
-                            .padding(.vertical, 5)
-                        VStack {
-                            Button(action: {needToEatASAP = .slowEat}) {
-                                Text(" ")
-                                    .frame(width: 10.adjusted, height: 10.adjusted)
-                                    .background(needToEatASAP == .slowEat ? greenBlueGradient : clearGradient)
-                                    .cornerRadius(100)
-                                    .padding(7)
-                                    .overlay(RoundedRectangle(cornerRadius: 100)
-                                        .stroke(LinearGradient(
-                                            gradient: needToEatASAP == .slowEat ? greenBlueGradient : notSelectedGradient,
-                                            startPoint: .leading,
-                                            endPoint: .trailing), lineWidth: 3)
-                                    )
-                                Text("천천히 먹어도 돼요")
-                                    .padding(.leading, 5.adjusted)
-                                    .foregroundColor(Color("Gray900"))
-                            }
-                            .padding(.horizontal, 20)
-                            .frame(width: 350.adjusted, height: 60.adjusted, alignment: .leading)
-                            .background(Color("Gray50"))
-                            .cornerRadius(15)
-                            .overlay(RoundedRectangle(cornerRadius: 15)
-                                .stroke(LinearGradient(
-                                    gradient:needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                ), lineWidth: 3)
-                                     
-                            )
-                        }
+                            .frame(width: 8, height: 8)
                     }
-                    .frame(width: 350.adjusted, alignment: .leading)
+                    .padding(.leading, 20)
+                    
+                    Text("빨리 먹어야 해요")
+                        .font(.system(size: 17, weight: .semibold))
+                        .padding(.leading, 5)
+                        .foregroundColor(Color("Gray900"))
+                    
                     Spacer()
                 }
-            } // first VStack
-            .padding(.horizontal, 20.adjusted)
+            }
+        })
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    LinearGradient(
+                        gradient: needToEatASAP == .fastEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    lineWidth: 2
+                )
+        )
+    }
+    
+    var slowEatRadioButton: some View {
+        Button(action: {
+            needToEatASAP = .slowEat
+        }, label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .frame(height: 60)
+                    .foregroundColor(Color("Gray50"))
+                
+                HStack {
+                    ZStack {
+                        Circle()
+                            .stroke(
+                                LinearGradient(
+                                    gradient: needToEatASAP == .slowEat ? greenBlueGradient: notSelectedGradient,
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ),
+                                lineWidth: 2
+                            )
+                            .frame(width: 20, height: 20)
+                        Circle()
+                            .fill(
+                                LinearGradient(
+                                    gradient: needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+                            .frame(width: 8, height: 8)
+                    }
+                    .padding(.leading, 20)
+                    
+                    Text("천천히 먹어도 돼요")
+                        .font(.system(size: 17, weight: .semibold))
+                        .padding(.leading, 5)
+                        .foregroundColor(Color("Gray900"))
+                    
+                    Spacer()
+                }
+            }
+        })
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    LinearGradient(
+                        gradient: needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    lineWidth: 2
+                )
+        )
+    }
+}
         
-        }
-        
-    struct ItemDetailView_Previews: PreviewProvider {
-        static var previews: some View {
-            ItemDetailView()
-        }
+struct ItemDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        ItemDetailView()
     }
 }


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #17/editItemDetialView
- 관련 이슈
    - #56 

👷 **작업한 내용**
- **ItemDetailView 수정**
    - 냉장고 선택 버튼 구조 및 디자인 변경
    - 전체 레이아웃 기기대응 가능하게 변경
    - EditItemDetailVew를 FullScreenCover로 띄우는 버튼 추가 후 뷰 연결
- **EditItemDetailView 구현**
    - 뷰 구현
    - EditIconDetailView를 Modal로 띄우는 버튼 추가 후 뷰 연결

## 🚨 참고 사항
- **ItemDetailView 수정**
    - 나중에 린의 EditIconDetailView랑 merge하면서 conflict날텐데 여기 뷰를 살려야됨.
- **EditItemDetailView 구현**
    - 아직 EditIcon뷰 구현 안돼서 CRUD는 추후 진행
        - ItemDetail <-> EditItem <-> EditIcon 3개의 뷰 간에 이름, 날짜, 금액, 아이콘 (CRUD)를 추후 구현 필요


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|itemDetailView|![item](https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/123388563/253e4cda-3f01-48a9-8629-918e48b07d1c)
|editItemDetialView|![edit](https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/123388563/11465e98-3a24-42fc-abb5-5c3d6f210e5d)

## 📟 관련 이슈
- Resolved: #56 
