### PR TITLE
fix: ItemDetailView Extension Delete

### DIFF
--- a/SickSangHae/View/EditItemDetailView.swift
+++ b/SickSangHae/View/EditItemDetailView.swift
@@ -7,15 +7,6 @@
 
 import SwiftUI
 
-extension View {
-    func endTextEditing() {
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder),
-            to: nil, from: nil, for: nil
-        )
-    }
-}
-
 struct EditItemDetailView: View {
     
     @Binding var isShowingEditView: Bool
@@ -40,7 +31,7 @@ struct EditItemDetailView: View {
         .padding(.horizontal, 20.adjusted)
         .ignoresSafeArea(.keyboard)
         .onTapGesture {
-            self.endTextEditing()
+            endTextEditing()
         }
     }
     


### PR DESCRIPTION
fix: ItemDetailView Extension Delete

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #17/comepletItemDetailView

👷 **작업한 내용**
- dev와 중복되는 endTextEditing 익스텐션 삭제

## 🚨 참고 사항
- none

## 📸 스크린샷
