### PR TITLE
#28/item detail view core data

### DIFF
--- a/SickSangHae/Global/Extensions/Date+Extension.swift
+++ b/SickSangHae/Global/Extensions/Date+Extension.swift
@@ -11,4 +11,10 @@ extension Date {
     var dateDifference: Int {
         return Calendar.current.dateComponents([.day], from: self, to: Date.now).day ?? 0
     }
+    
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        return formatter.string(from: self)
+    }
 }

--- a/SickSangHae/View/EditIconDetailView.swift
+++ b/SickSangHae/View/EditIconDetailView.swift
@@ -12,7 +12,12 @@ struct EditIconDetailView: View {
     
     let iconImages = ["supplements", "nuts", "grains", "fruits", "snacks", "frozenFoods", "eggs", "deliFoods", "ddeuk", "dumples", "noodles", "mealkits", "rices", "breads", "sauces", "seafoods", "cereals", "cookingOils", "iceCream", "dairies", "meats", "beverages", "koreanSauces", "seasonings", "liquors", "retortFoods", "jams", "teas", "chocolates", "friedChicken", "vegetables", "coffee", "beans", "cannedFoods", "seaweeds", "hamSausage"]
     
-    @State var currentIcon: String = "shoppingCart"
+    var iconDict: Dictionary<String, String> {
+        Dictionary(uniqueKeysWithValues: zip(iconImages, iconTitles))
+    }
+    
+    @Binding var receiptIcon: String
+    @State var currentIcon: String
     @Environment(\.dismiss) var dismiss
     var body: some View {
         
@@ -29,7 +34,8 @@ struct EditIconDetailView: View {
                 Spacer()
                 Button(action: {
                     // 변경된 icon 저장하는 로직
-                    
+                    receiptIcon = currentIcon
+                    dismiss()
                 }, label: {
                     Text("완료")
                         .bold()
@@ -64,7 +70,8 @@ struct EditIconDetailView: View {
                     }
                     
                 }
-                Text("계란 30구")
+//                Text("계란 30구")
+                Text(iconDict[currentIcon] ?? "쇼핑카트")
                     .font(.title2)
                     .bold()
                     .padding(screenHeight * 0.028)
@@ -96,11 +103,8 @@ struct EditIconDetailView: View {
     }
 }
 
-func didDismiss() {
-}
-
 struct EditIconDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        EditIconDetailView()
+        EditIconDetailView(receiptIcon: .constant("bread"), currentIcon: "shoppingCart")
     }
 }

--- a/SickSangHae/View/HistoryView.swift
+++ b/SickSangHae/View/HistoryView.swift
@@ -151,7 +151,7 @@ struct HistoryView: View {
         ForEach(isMovingSegmentedTab ? coreDataViewModel.eatenList : coreDataViewModel.spoiledList, id:\.self) { item in
             VStack {
                 HStack {
-                    Image(systemName: "circle.fill")
+                    Image(item.icon)
                         .resizable()
                         .foregroundColor(Color("Gray200"))
                         .frame(width: 36, height: 36)

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -7,20 +7,38 @@
 
 import SwiftUI
 
-enum selected{
-    case basic
-    case fastEat
-    case slowEat
-    case unselected
-}
+//enum selected{
+//    case basic
+//    case fastEat
+//    case slowEat
+//    case unselected
+//}
 
 struct ItemDetailView: View {
     var greenBlueGradient = Gradient(colors: [Color("PrimaryG"), Color("PrimaryB")])
     var notSelectedGradient = Gradient(colors: [Color("Gray200"), Color("Gray200")])
     var clearGradient = Gradient(colors: [.clear, .clear])
     
-    @State var needToEatASAP: selected = .unselected
+    @State var appState: AppState
+    
     @State private var isShowingEditView = false
+    
+    @State var receipt: Receipt
+    
+    @EnvironmentObject var coreDateViewModel: CoreDataViewModel
+    
+    //    @State var needToEatASAP: selected = .unselected
+        @State var needToEatASAP: Status {
+            didSet {
+                coreDateViewModel.updateStatus(target: receipt, to: needToEatASAP)
+            }
+        }
+    
+    init(receipt: Receipt, appState: AppState) {
+        self.receipt = receipt
+        self.needToEatASAP = receipt.currentStatus
+        self.appState = appState
+    }
     
     var body: some View {
         
@@ -62,19 +80,23 @@ struct ItemDetailView: View {
                 .padding(.horizontal, 20.adjusted)
                 .padding(.bottom, 40)
             } //ScrollView닫기
-            SmallButtonView()
+            SmallButtonView(receipt: receipt)
         } // VStack닫기
     } //body닫기
         
     var topNaviBar: some View {
         HStack {
-            Image(systemName: "chevron.left")
-                .resizable()
-                .frame(width: 10, height: 18)
-            
+            Button {
+                print("clicked")
+                appState.moveToRootView = true
+            } label: {
+                Image(systemName: "chevron.left")
+                    .resizable()
+                    .frame(width: 10, height: 18)
+            }
             Spacer()
             
-            Text("계란 30구")
+            Text("\(receipt.name)")
                 .bold()
                 .padding(.leading, 15)
             
@@ -88,7 +110,7 @@ struct ItemDetailView: View {
                     .foregroundColor(.black)
             })
             .fullScreenCover(isPresented: $isShowingEditView) {
-                EditItemDetailView(isShowingEditView: $isShowingEditView)
+                EditItemDetailView(isShowingEditView: $isShowingEditView, iconText: receipt.icon, nameText: receipt.name, dateText: receipt.dateOfPurchase, wonText: "\(receipt.price)", appState: appState, receipt: receipt)
             }
         } //HStack닫기
         .padding(.top, 10)
@@ -101,11 +123,12 @@ struct ItemDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     
                     HStack {
-                        Circle()
+                        Image(receipt.icon)
+                            .resizable()
                             .foregroundColor(Color("Gray200"))
-                            .frame(width: 80)
+                            .frame(width: 80, height: 80)
                         
-                        Text("계란 30구")
+                        Text("\(receipt.name)")
                             .font(.system(size: 22, weight: .bold))
                             .padding(.leading, 15)
                     }
@@ -116,7 +139,7 @@ struct ItemDetailView: View {
                         .foregroundColor(Color("Gray600"))
                         .padding(.bottom, 12)
                     
-                    Text("2023년 7월 39일")
+                    Text("\(receipt.dateOfPurchase.formattedDate)")
                         .font(.system(size: 20, weight: .bold))
                         .padding(.bottom, 30)
                     
@@ -125,7 +148,7 @@ struct ItemDetailView: View {
                         .foregroundColor(Color("Gray600"))
                         .padding(.bottom, 12)
                     
-                    Text("9,800원")
+                    Text("\(Int(receipt.price))원")
                         .font(.system(size: 20, weight: .bold))
                         .padding(.bottom, 30)
                 }
@@ -145,7 +168,8 @@ struct ItemDetailView: View {
     
     var bacicRadioButton: some View {
         Button(action: {
-            needToEatASAP = .basic
+//            needToEatASAP = .basic
+            needToEatASAP = .shortTermUnEaten
         }, label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
@@ -155,9 +179,17 @@ struct ItemDetailView: View {
                 HStack {
                     ZStack {
                         Circle()
+//                            .stroke(
+//                                LinearGradient(
+//                                    gradient: needToEatASAP == .basic ? greenBlueGradient: notSelectedGradient,
+//                                    startPoint: .leading,
+//                                    endPoint: .trailing
+//                                ),
+//                                lineWidth: 2
+//                            )
                             .stroke(
                                 LinearGradient(
-                                    gradient: needToEatASAP == .basic ? greenBlueGradient: notSelectedGradient,
+                                    gradient: needToEatASAP == .shortTermUnEaten ? greenBlueGradient: notSelectedGradient,
                                     startPoint: .leading,
                                     endPoint: .trailing
                                 ),
@@ -165,9 +197,16 @@ struct ItemDetailView: View {
                             )
                             .frame(width: 20, height: 20)
                         Circle()
+//                            .fill(
+//                                LinearGradient(
+//                                    gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+//                                    startPoint: .leading,
+//                                    endPoint: .trailing
+//                                )
+//                            )
                             .fill(
                                 LinearGradient(
-                                    gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                                    gradient: needToEatASAP == .shortTermUnEaten ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                                     startPoint: .leading,
                                     endPoint: .trailing
                                 )
@@ -187,9 +226,17 @@ struct ItemDetailView: View {
         })
         .overlay(
             RoundedRectangle(cornerRadius: 8)
+//                .stroke(
+//                    LinearGradient(
+//                        gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+//                        startPoint: .leading,
+//                        endPoint: .trailing
+//                    ),
+//                    lineWidth: 2
+//                )
                 .stroke(
                     LinearGradient(
-                        gradient: needToEatASAP == .basic ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                        gradient: needToEatASAP == .shortTermUnEaten ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                         startPoint: .leading,
                         endPoint: .trailing
                     ),
@@ -201,7 +248,8 @@ struct ItemDetailView: View {
     
     var fastEatRadioButton: some View {
         Button(action: {
-            needToEatASAP = .fastEat
+//            needToEatASAP = .fastEat
+            needToEatASAP = .shortTermPinned
         }, label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
@@ -211,9 +259,17 @@ struct ItemDetailView: View {
                 HStack {
                     ZStack {
                         Circle()
+//                            .stroke(
+//                                LinearGradient(
+//                                    gradient: needToEatASAP == .fastEat ? greenBlueGradient: notSelectedGradient,
+//                                    startPoint: .leading,
+//                                    endPoint: .trailing
+//                                ),
+//                                lineWidth: 2
+//                            )
                             .stroke(
                                 LinearGradient(
-                                    gradient: needToEatASAP == .fastEat ? greenBlueGradient: notSelectedGradient,
+                                    gradient: needToEatASAP == .shortTermPinned ? greenBlueGradient: notSelectedGradient,
                                     startPoint: .leading,
                                     endPoint: .trailing
                                 ),
@@ -221,9 +277,16 @@ struct ItemDetailView: View {
                             )
                             .frame(width: 20, height: 20)
                         Circle()
+//                            .fill(
+//                                LinearGradient(
+//                                    gradient: needToEatASAP == .fastEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+//                                    startPoint: .leading,
+//                                    endPoint: .trailing
+//                                )
+//                            )
                             .fill(
                                 LinearGradient(
-                                    gradient: needToEatASAP == .fastEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                                    gradient: needToEatASAP == .shortTermPinned ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                                     startPoint: .leading,
                                     endPoint: .trailing
                                 )
@@ -243,9 +306,17 @@ struct ItemDetailView: View {
         })
         .overlay(
             RoundedRectangle(cornerRadius: 8)
+//                .stroke(
+//                    LinearGradient(
+//                        gradient: needToEatASAP == .fastEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+//                        startPoint: .leading,
+//                        endPoint: .trailing
+//                    ),
+//                    lineWidth: 2
+//                )
                 .stroke(
                     LinearGradient(
-                        gradient: needToEatASAP == .fastEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                        gradient: needToEatASAP == .shortTermPinned ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                         startPoint: .leading,
                         endPoint: .trailing
                     ),
@@ -256,7 +327,8 @@ struct ItemDetailView: View {
     
     var slowEatRadioButton: some View {
         Button(action: {
-            needToEatASAP = .slowEat
+//            needToEatASAP = .slowEat
+            needToEatASAP = .longTermUnEaten
         }, label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
@@ -266,9 +338,17 @@ struct ItemDetailView: View {
                 HStack {
                     ZStack {
                         Circle()
+//                            .stroke(
+//                                LinearGradient(
+//                                    gradient: needToEatASAP == .slowEat ? greenBlueGradient: notSelectedGradient,
+//                                    startPoint: .leading,
+//                                    endPoint: .trailing
+//                                ),
+//                                lineWidth: 2
+//                            )
                             .stroke(
                                 LinearGradient(
-                                    gradient: needToEatASAP == .slowEat ? greenBlueGradient: notSelectedGradient,
+                                    gradient: needToEatASAP == .longTermUnEaten ? greenBlueGradient: notSelectedGradient,
                                     startPoint: .leading,
                                     endPoint: .trailing
                                 ),
@@ -276,9 +356,16 @@ struct ItemDetailView: View {
                             )
                             .frame(width: 20, height: 20)
                         Circle()
+//                            .fill(
+//                                LinearGradient(
+//                                    gradient: needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+//                                    startPoint: .leading,
+//                                    endPoint: .trailing
+//                                )
+//                            )
                             .fill(
                                 LinearGradient(
-                                    gradient: needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                                    gradient: needToEatASAP == .longTermUnEaten ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                                     startPoint: .leading,
                                     endPoint: .trailing
                                 )
@@ -298,9 +385,17 @@ struct ItemDetailView: View {
         })
         .overlay(
             RoundedRectangle(cornerRadius: 8)
+//                .stroke(
+//                    LinearGradient(
+//                        gradient: needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+//                        startPoint: .leading,
+//                        endPoint: .trailing
+//                    ),
+//                    lineWidth: 2
+//                )
                 .stroke(
                     LinearGradient(
-                        gradient: needToEatASAP == .slowEat ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
+                        gradient: needToEatASAP == .longTermUnEaten ? greenBlueGradient : Gradient(colors: [.clear, .clear]),
                         startPoint: .leading,
                         endPoint: .trailing
                     ),
@@ -311,7 +406,8 @@ struct ItemDetailView: View {
 }
         
 struct ItemDetailView_Previews: PreviewProvider {
+    static let coreDataViewModel = CoreDataViewModel()
     static var previews: some View {
-        ItemDetailView()
+        ItemDetailView(receipt: Receipt(context: coreDataViewModel.viewContext), appState: AppState())
     }
 }

--- a/SickSangHae/View/MainView.swift
+++ b/SickSangHae/View/MainView.swift
@@ -22,6 +22,8 @@ struct MainView: View {
     @State var text: String = ""
     
     @EnvironmentObject var coreDataViewModel: CoreDataViewModel
+    
+    @State var appState = AppState()
 
     var body: some View {
 
@@ -60,9 +62,9 @@ struct MainView: View {
 
             switch selectedTopTabBar {
             case .basic:
-                BasicList()
+                BasicList(appState: appState)
             case .longterm:
-                LongTermList(itemList: coreDataViewModel.longTermUnEatenList, swipeOffsets: coreDataViewModel.longTermUnEatenOffsets, status: .longTermUnEaten)
+                LongTermList(coreDataViewModel: coreDataViewModel, listContentViewModel: ListContentViewModel(status: .longTermUnEaten, itemList: coreDataViewModel.longTermUnEatenList), appState: appState)
             }
             
         }

--- a/SickSangHae/View/Reusable/BasicList.swift
+++ b/SickSangHae/View/Reusable/BasicList.swift
@@ -53,7 +53,7 @@ struct BasicList: View {
                 .padding(.trailing, 20)
             }
             .padding([.top, .bottom], 17)
-            .padding([.leading], 20)
+            .padding(.leading, 20)
     }
     
     private var PinnedListTitle: some View {
@@ -64,8 +64,8 @@ struct BasicList: View {
                 
                 Spacer()
             }
-            .padding([.top, .bottom], 17)
-            .padding([.leading, .trailing], 20)
+            .padding(.vertical, 17)
+            .padding(.horizontal, 20)
         }
 }
 
@@ -159,7 +159,7 @@ Array(zip(listContentViewModel.itemList.indices, listContentViewModel.itemList.r
                                 .font(.system(size: 14).weight(.semibold))
                                 .padding(.trailing, 20)
                         }
-                        .padding([.top, .bottom], 8)
+                        .padding(.vertical, 8)
                     }
                     .gesture(DragGesture().onChanged({ value in
                         withAnimation {

--- a/SickSangHae/View/Reusable/SmallButtonView.swift
+++ b/SickSangHae/View/Reusable/SmallButtonView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 
 struct SmallButtonView: View {
+    
+    @EnvironmentObject var coreDataViewModel: CoreDataViewModel
+    let receipt: Receipt
+    
     var body: some View {
         ZStack {
             VStack(spacing: 0){
@@ -16,7 +20,7 @@ struct SmallButtonView: View {
                     .frame(width: 390.adjusted, height: 1.adjusted)
                 HStack {
                     Button {
-                        
+                        coreDataViewModel.updateStatus(target: receipt, to: .Eaten)
                     } label: {
                         ZStack {
                             Rectangle()
@@ -29,7 +33,7 @@ struct SmallButtonView: View {
                     .buttonStyle(CustomButtonStyle())
                     Spacer()
                     Button {
-                        
+                        coreDataViewModel.updateStatus(target: receipt, to: .Spoiled)
                     } label: {
                         ZStack {
                             Rectangle()
@@ -59,8 +63,10 @@ struct SmallButtonView: View {
     
     
     struct SmallButtonView_Previews: PreviewProvider {
+        static let coreDataViewModel = CoreDataViewModel()
         static var previews: some View {
-            SmallButtonView()
+            SmallButtonView(receipt: Receipt(context: coreDataViewModel.viewContext))
+                .environmentObject(coreDataViewModel)
         }
     }
 }

--- a/SickSangHae/View/TabBarView.swift
+++ b/SickSangHae/View/TabBarView.swift
@@ -160,3 +160,8 @@ struct CustomTabView: View {
 
 
 
+struct TabBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        TabBarView(appState: AppState())
+    }
+}


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #28/itemDetailVIewCoreData

👷 **작업한 내용**
- MainView 의 리팩토링을 진행했습니다
- ItemDetailView 의 체크박스 선택시 자동으로 해당 항목의 status 가 변하게 하였습니다
- 먹었어요 상했어요 버튼을 누르면 해당하는 status 로 항목의 status 가 변합니다
- EditItemDetailView 에 각 text field 에 대응하여 완료를 누르면 해당 항목의 값이 변하게 하였습니다.
- EditIconDetailView 에서 icon 을 바꿨을때는 sheet 의 icon 만 변하고, 완료를 누를 시 EditItemDetailView 의 icon 이 변하게 하였습니다

## 🚨 참고 사항
- EditItemDetailView 에서 삭제 구현 해야함(뷰가 사라지기전에 coredata 가 삭제되서 runtime error 가 뜨는 상황 발생)
- ItemDetailView 에서 커스텀 Navbar 뒤로가기 버튼 구현해야함
- MainView 의 basic list 의 최신순, 오래된순 버튼 작동 안함. longterm list 에서는 잘 작동함

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|DetailItemView 에서 라디오버튼을 통한 상태변경|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/a06319db-e7d2-4536-ae3f-51226078199e.gif">
|EditItemDetailView 에서 항목 업데이트 및 저장|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/64cd9528-3b3c-487d-b672-502de8f4c5ee.gif">
|EditIconDetailView 에서 icon 선택 및 EditItemDetailView 에 가져오기|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/85ec6a39-c8b5-4584-b096-b73f8b3158a8.gif">
|전체 수정내용 저장 및 적용확인|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/04b5c871-b60e-42c5-984e-d4823ae37654.gif">
|먹었어요 상했어요 상태 복구하기|<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/6ea26453-576c-45b9-9fa0-df9be21397d5.gif">


## 📟 관련 이슈
- Resolved: #72 
