### PR TITLE
#64/ChatGPT OpenAI GPT prompt setting

### DIFF
--- a/SickSangHae/View/ItemCheckView.swift
+++ b/SickSangHae/View/ItemCheckView.swift
@@ -122,9 +122,8 @@ struct ItemCheckView: View {
 
                 ForEach(0..<gptAnswer["상품명"]!.count, id: \.self) { index in
                     let productName = gptAnswer["상품명"]![index] as! String
-                    let price = gptAnswer["단가"]![index] as! Int
                     let quantity = gptAnswer["수량"]![index] as! Int
-                    let amount = gptAnswer["금액"]![index] as! Int
+                    let price = gptAnswer["금액"]![index] as! Int
 
                     listDetail(listTraling: productName, listLeading: String(price), listColor: "Gray900")
                     

--- a/SickSangHae/ViewModel/OCRViewModel.swift
+++ b/SickSangHae/ViewModel/OCRViewModel.swift
@@ -123,7 +123,7 @@ class OCRViewModel: ObservableObject {
     func queryGPT(prompts: String, dispatchGroup: DispatchGroup, completion: @escaping (String) -> Void) {
         let configuration = OpenAI.Configuration(token: chatToken, organizationIdentifier: chatOrganization, timeoutInterval: 60.0)
         let openAI = OpenAI(configuration: configuration)
-        let customPrompt = prompts + "\n 이거를 딕셔너리로 정리해. 그리고 key는 상품명, 단가, 수량, 금액이야. value는 리스트형식이야. 단가, 수량, 금액에 대한 value의 list 요소들은 Int형으로 나와야 해. 딕셔너리만 응답해줘."
+        let customPrompt = prompts + "\n 이거를 딕셔너리로 정리해. 다음과 같은 포맷으로 줘야해. {\"상품명\": [], \"수량\": [], \"금액\": []}. 특수문자는 모두 제거해. 상품명에는 수량, 금액을 제거해.  수량, 금액은 Int형으로 되어있어야 해. 상품명, 수량, 금액 중에 비어 있는게 있으면 1을 추가해서 넣어. null은 모두 1로 바꿔. 그리고 상품명 value의 array size와 수량, 금액 value의 array size가 다르면 수량, 금액 value의  array size가 같아지도록 1을 추가해. 오직 딕셔너리만 응답해야 돼. 다른 말 하지마."
 
         let query = ChatQuery(model: .gpt3_5Turbo, messages: [.init(role: .user, content: customPrompt)])
         
@@ -159,7 +159,7 @@ class OCRViewModel: ObservableObject {
             do {
                 return try JSONSerialization.jsonObject(with: data, options: []) as? [String: [Any]]
             } catch {
-                print(error.localizedDescription)
+                return ["상품명": ["스캔이 올바르지 않아요"], "단가": [0], "수량": [0], "금액": [0]]
             }
         }
         return nil


### PR DESCRIPTION
feature: GPT prompt

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #64 

👷 **작업한 내용**
- ChatGPT의 정확도를 높이기 위해 쿼리문에 제약조건을 넣기
- ChatGPT 응답에 대한 예외처리하기

## 🚨 참고 사항
- 이제 거의 모든 경우에 대한 예외처리를 했어요.
- 알려지지 않은 엣지케이스가 있을 수 있으니 함께 찾아보아요 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|이마트몰|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/8f7205bb-5f57-4725-9b21-282d8a4179d9">
|SSG|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/e2529e0e-3215-42cf-bc3f-15ba81e81cff">
|쿠팡|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/21f6492f-1e58-4aa7-b568-24deb630c755">
|마켓컬리 인식실패|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/c967b750-1424-4ec8-b6d3-347a6d4e6b1b">
|마켓컬리 인식성공|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/15444263-1b71-42c0-9d0d-92633013b3f4">
|홈플러스 영수증|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/01e19ecf-e949-435d-8baf-a0b09abfc6e2">

![Jul-27-2023 23-52-58]()

## 📟 관련 이슈
- Resolved: #
