### PR TITLE
#59/direct input flow

### DIFF
--- a/SickSangHae.xcodeproj/project.pbxproj
+++ b/SickSangHae.xcodeproj/project.pbxproj
@@ -128,7 +128,6 @@
 		8787EC032A5FD48800104EDE /* UpperTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpperTabBar.swift; sourceTree = "<group>"; };
 		8787EC052A5FE7CE00104EDE /* ItemBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemBlockView.swift; sourceTree = "<group>"; };
 		CE0319E62A6D5221009580F6 /* Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Categories.swift; sourceTree = "<group>"; };
-		CE04EA0C2A73803900CFBE4E /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		CE9AFD8F2A5FE33000EB2D8C /* SickSangHaeModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SickSangHaeModel.xcdatamodel; sourceTree = "<group>"; };
 		CE9AFD952A5FEC9100EB2D8C /* Receipt+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Receipt+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CE9AFD962A5FEC9100EB2D8C /* Receipt+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Receipt+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -160,7 +159,6 @@
 		027E96662A56AB5E0066BA8F = {
 			isa = PBXGroup;
 			children = (
-				CE04EA0C2A73803900CFBE4E /* Secrets.xcconfig */,
 				027E96712A56AB5E0066BA8F /* SickSangHae */,
 				7CEB9EB12A613D7C008B70FD /* SickSangHaeTests */,
 				027E96702A56AB5E0066BA8F /* Products */,
@@ -617,7 +615,6 @@
 		};
 		027E967E2A56AB5F0066BA8F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CE04EA0C2A73803900CFBE4E /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/SickSangHae.xcodeproj/project.pbxproj
+++ b/SickSangHae.xcodeproj/project.pbxproj
@@ -108,7 +108,6 @@
 		02FC0ED72A6C5DF100B4284C /* TopAlertModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopAlertModel.swift; sourceTree = "<group>"; };
 		237674E82A6516C200E92BAB /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		7C16FB3F2A7170030025BC20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		7C16FB492A7182D10025BC20 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		7C41D9502A6280690054FD04 /* BasicList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicList.swift; sourceTree = "<group>"; };
 		7C41D9522A62807A0054FD04 /* LongTermList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTermList.swift; sourceTree = "<group>"; };
 		7C41D9542A62808D0054FD04 /* OCRView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRView.swift; sourceTree = "<group>"; };
@@ -129,6 +128,7 @@
 		8787EC032A5FD48800104EDE /* UpperTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpperTabBar.swift; sourceTree = "<group>"; };
 		8787EC052A5FE7CE00104EDE /* ItemBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemBlockView.swift; sourceTree = "<group>"; };
 		CE0319E62A6D5221009580F6 /* Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Categories.swift; sourceTree = "<group>"; };
+		CE04EA0C2A73803900CFBE4E /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		CE9AFD8F2A5FE33000EB2D8C /* SickSangHaeModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SickSangHaeModel.xcdatamodel; sourceTree = "<group>"; };
 		CE9AFD952A5FEC9100EB2D8C /* Receipt+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Receipt+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CE9AFD962A5FEC9100EB2D8C /* Receipt+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Receipt+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -160,7 +160,7 @@
 		027E96662A56AB5E0066BA8F = {
 			isa = PBXGroup;
 			children = (
-				7C16FB492A7182D10025BC20 /* Secrets.xcconfig */,
+				CE04EA0C2A73803900CFBE4E /* Secrets.xcconfig */,
 				027E96712A56AB5E0066BA8F /* SickSangHae */,
 				7CEB9EB12A613D7C008B70FD /* SickSangHaeTests */,
 				027E96702A56AB5E0066BA8F /* Products */,
@@ -207,7 +207,6 @@
 				CE9AFD992A5FED9200EB2D8C /* ItemStatus.swift */,
 				CE9AFD9B2A5FEFE400EB2D8C /* PersistentController.swift */,
 				02D4497F2A5FEFF600D97A37 /* CameraModel.swift */,
-				02FC0ED72A6C5DF100B4284C /* TopAlertModel.swift */,
 				CE0319E62A6D5221009580F6 /* Categories.swift */,
 				02FC0ED72A6C5DF100B4284C /* TopAlertModel.swift */,
 			);
@@ -618,13 +617,14 @@
 		};
 		027E967E2A56AB5F0066BA8F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CE04EA0C2A73803900CFBE4E /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SickSangHae/Preview Content\"";
-				DEVELOPMENT_TEAM = 2QWMDJG53V;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SickSangHae/Info.plist;
@@ -656,7 +656,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SickSangHae/Preview Content\"";
-				DEVELOPMENT_TEAM = 2QWMDJG53V;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SickSangHae/Info.plist;

--- a/SickSangHae/Application/SickSangHaeApp.swift
+++ b/SickSangHae/Application/SickSangHaeApp.swift
@@ -10,7 +10,6 @@ import SwiftUI
 @main
 struct SickSangHaeApp: App {
     @StateObject private var cameraViewModelShared = CameraViewModel()
-
     var body: some Scene {
         WindowGroup {
         let appState = AppState()

--- a/SickSangHae/View/CameraView.swift
+++ b/SickSangHae/View/CameraView.swift
@@ -13,6 +13,8 @@ struct CameraView: View {
   @Environment(\.dismiss) private var dismiss
   let appState: AppState
     
+    @State private var isDirectInput = false
+    
   var body: some View {
     ZStack {
       viewModel.cameraPreview.ignoresSafeArea()
@@ -43,7 +45,7 @@ struct CameraView: View {
           flashButton
         }
         .padding([.leading, .trailing, .bottom], 32.adjusted)
-        selfAddButton
+//        selfAddButton
       }
     }
     .navigationBarBackButtonHidden(true)
@@ -119,32 +121,36 @@ struct CameraView: View {
     .foregroundColor(.white)
   }
   
-  private var selfAddButton: some View {
-    //navitagtion 추가
-    Button (action: { }) {
-      ZStack(alignment: .center) {
-        Rectangle()
-          .foregroundColor(.clear)
-          .frame(height: 60.adjusted)
-          .cornerRadius(15)
-          .overlay(
-            RoundedRectangle(cornerRadius: 15)
-              .inset(by: 1)
-              .stroke(.white, lineWidth: 2)
-          )
-        HStack(spacing: 8.adjusted) {
-          Image(systemName: "pencil.circle")
-            .resizable()
-            .frame(width: 19.adjusted, height: 19.adjusted)
-          Text("직접 추가하기")
-            .font(.system(size: 17))
-        }
-      }
-      .foregroundColor(.white)
-    }
-    .padding(.horizontal, 24.adjusted)
-    .padding(.bottom, 20.adjusted)
-  }
+//  private var selfAddButton: some View {
+//      NavigationLink(destination: UpdateItemView(viewModel: UpdateItemViewModel(), titleName: "직접 추가", buttonName: "다음", appState: appState), isActive: $isDirectInput) {
+//          Button {
+//              print("Clicked")
+//              isDirectInput = true
+//          } label: {
+//              ZStack(alignment: .center) {
+//                  Rectangle()
+//                      .foregroundColor(.clear)
+//                      .frame(height: 60.adjusted)
+//                      .cornerRadius(15)
+//                      .overlay(
+//                        RoundedRectangle(cornerRadius: 15)
+//                            .inset(by: 1)
+//                            .stroke(.white, lineWidth: 2)
+//                      )
+//                  HStack(spacing: 8.adjusted) {
+//                      Image(systemName: "pencil.circle")
+//                          .resizable()
+//                          .frame(width: 19.adjusted, height: 19.adjusted)
+//                      Text("직접 추가하기")
+//                          .font(.system(size: 17))
+//                  }
+//              }
+//              .foregroundColor(.white)
+//          }
+//          .padding(.horizontal, 24.adjusted)
+//          .padding(.bottom, 20.adjusted)
+//      }
+//    }
 }
 
 struct CameraPreviewView: UIViewRepresentable {

--- a/SickSangHae/View/ItemCheckView.swift
+++ b/SickSangHae/View/ItemCheckView.swift
@@ -15,6 +15,9 @@ struct ItemCheckView: View {
     var isOCR = true
     @ObservedObject var viewModel = UpdateItemViewModel()
     @State var appState: AppState
+    @State private var isRegisterCompleteView = false
+    
+    @EnvironmentObject var coreDataViewModel: CoreDataViewModel
     
     var body: some View {
         NavigationStack {
@@ -54,7 +57,7 @@ struct ItemCheckView: View {
                     }
                     
                     Spacer()
-                    NavigationLink(destination: RegisterCompleteView(appState: appState), label: {
+                    NavigationLink(destination: RegisterCompleteView(appState: appState) ,label: {
                         ZStack {
                             Rectangle()
                                 .frame(width: 350, height: 60)
@@ -67,6 +70,9 @@ struct ItemCheckView: View {
                             }
                         }
                         .padding(.bottom, 30)
+                        .onTapGesture {
+                            registerItemsToCoreData()
+                        }
                     })
                 }
             }
@@ -83,7 +89,7 @@ struct ItemCheckView: View {
             
             switch isOCR{
             case true:
-                NavigationLink(destination: UpdateItemView(viewModel: UpdateItemViewModel(),titleName: "수정", buttonName: "수정 완료", appState: appState), label: {
+                NavigationLink(destination: UpdateItemView(viewModel: UpdateItemViewModel(),titleName: "수정", buttonName: "수정 완료",gptAnswer: $gptAnswer, appState: appState), label: {
                 ZStack{
                     RoundedRectangle(cornerRadius: 5)
                         .foregroundColor(Color("Gray100"))
@@ -153,6 +159,12 @@ struct ItemCheckView: View {
         .padding([.top, .bottom], 8.adjusted)
     }
     
+    
+    func registerItemsToCoreData() {
+        for i in 0..<gptAnswer["상품명"]!.count {
+//            coreDataViewModel.createReceiptData(name: gptAnswer["상품명"]![i] as! String, price: Double(gptAnswer["금액"]![i] as! Int))
+        }
+    }
 }
 
 //struct ItemCheckView_Previews: PreviewProvider {

--- a/SickSangHae/View/ItemCheckView.swift
+++ b/SickSangHae/View/ItemCheckView.swift
@@ -108,19 +108,6 @@ struct ItemCheckView: View {
                     .foregroundColor(Color("Gray600"))
                     .padding(.trailing, 20.adjusted)
                 }
-//                NavigationLink(destination: UpdateItemView(viewModel: UpdateItemViewModel(),titleName: "수정", buttonName: "수정 완료",gptAnswer: $gptAnswer, appState: appState), label: {
-//                ZStack{
-//                    RoundedRectangle(cornerRadius: 5)
-//                        .foregroundColor(Color("Gray100"))
-//
-//                    Text("수정")
-//                        .foregroundColor(Color("Gray600"))
-//                        .font(.system(size: 14.adjusted))
-//                }
-//                .frame(width: 45, height: 25)
-//                .foregroundColor(Color("Gray600"))
-//                .padding(.trailing, 20.adjusted)
-//                })
             default:
                 EmptyView()
             }

--- a/SickSangHae/View/ItemCheckView.swift
+++ b/SickSangHae/View/ItemCheckView.swift
@@ -16,7 +16,7 @@ struct ItemCheckView: View {
     @ObservedObject var viewModel = UpdateItemViewModel()
     @State var appState: AppState
     @State private var isRegisterCompleteView = false
-    @State private var isShowingUpdateItemView = true
+    @State private var isShowingUpdateItemView = false
     
     @EnvironmentObject var coreDataViewModel: CoreDataViewModel
     
@@ -78,6 +78,9 @@ struct ItemCheckView: View {
                 }
             }
             .navigationBarBackButtonHidden(true)
+            .fullScreenCover(isPresented: $isShowingUpdateItemView) {
+                UpdateItemView(viewModel: UpdateItemViewModel(),titleName: "수정", buttonName: "수정 완료",gptAnswer: $gptAnswer, appState: appState)
+            }
         }
     }
     private var ListTitle: some View {
@@ -90,9 +93,6 @@ struct ItemCheckView: View {
             
             switch isOCR{
             case true:
-                NavigationLink("",isActive: $isShowingUpdateItemView) {
-                    UpdateItemView(viewModel: UpdateItemViewModel(), titleName: "수정", buttonName: "수정 완료", gptAnswer: $gptAnswer, appState: appState)
-                }
                 Button {
                     isShowingUpdateItemView = true
                 } label: {
@@ -181,7 +181,7 @@ struct ItemCheckView: View {
     
     func registerItemsToCoreData() {
         for i in 0..<gptAnswer["상품명"]!.count {
-//            coreDataViewModel.createReceiptData(name: gptAnswer["상품명"]![i] as! String, price: Double(gptAnswer["금액"]![i] as! Int))
+            coreDataViewModel.createReceiptData(name: gptAnswer["상품명"]![i] as! String, price: Double(gptAnswer["금액"]![i] as! Int))
         }
     }
 }

--- a/SickSangHae/View/ItemCheckView.swift
+++ b/SickSangHae/View/ItemCheckView.swift
@@ -16,6 +16,7 @@ struct ItemCheckView: View {
     @ObservedObject var viewModel = UpdateItemViewModel()
     @State var appState: AppState
     @State private var isRegisterCompleteView = false
+    @State private var isShowingUpdateItemView = true
     
     @EnvironmentObject var coreDataViewModel: CoreDataViewModel
     
@@ -89,19 +90,37 @@ struct ItemCheckView: View {
             
             switch isOCR{
             case true:
-                NavigationLink(destination: UpdateItemView(viewModel: UpdateItemViewModel(),titleName: "수정", buttonName: "수정 완료",gptAnswer: $gptAnswer, appState: appState), label: {
-                ZStack{
-                    RoundedRectangle(cornerRadius: 5)
-                        .foregroundColor(Color("Gray100"))
-                    
-                    Text("수정")
-                        .foregroundColor(Color("Gray600"))
-                        .font(.system(size: 14.adjusted))
+                NavigationLink("",isActive: $isShowingUpdateItemView) {
+                    UpdateItemView(viewModel: UpdateItemViewModel(), titleName: "수정", buttonName: "수정 완료", gptAnswer: $gptAnswer, appState: appState)
                 }
-                .frame(width: 45, height: 25)
-                .foregroundColor(Color("Gray600"))
-                .padding(.trailing, 20.adjusted)
-                })
+                Button {
+                    isShowingUpdateItemView = true
+                } label: {
+                    ZStack{
+                        RoundedRectangle(cornerRadius: 5)
+                            .foregroundColor(Color("Gray100"))
+                        
+                        Text("수정")
+                            .foregroundColor(Color("Gray600"))
+                            .font(.system(size: 14.adjusted))
+                    }
+                    .frame(width: 45, height: 25)
+                    .foregroundColor(Color("Gray600"))
+                    .padding(.trailing, 20.adjusted)
+                }
+//                NavigationLink(destination: UpdateItemView(viewModel: UpdateItemViewModel(),titleName: "수정", buttonName: "수정 완료",gptAnswer: $gptAnswer, appState: appState), label: {
+//                ZStack{
+//                    RoundedRectangle(cornerRadius: 5)
+//                        .foregroundColor(Color("Gray100"))
+//
+//                    Text("수정")
+//                        .foregroundColor(Color("Gray600"))
+//                        .font(.system(size: 14.adjusted))
+//                }
+//                .frame(width: 45, height: 25)
+//                .foregroundColor(Color("Gray600"))
+//                .padding(.trailing, 20.adjusted)
+//                })
             default:
                 EmptyView()
             }

--- a/SickSangHae/View/Reusable/BasicList.swift
+++ b/SickSangHae/View/Reusable/BasicList.swift
@@ -181,8 +181,6 @@ Array(zip(listContentViewModel.itemList.indices, listContentViewModel.itemList.r
                         }))
                 }
                 .offset(x: listContentViewModel.offsets[index])
-                
-                
             }
             
             

--- a/SickSangHae/View/Reusable/OCRView.swift
+++ b/SickSangHae/View/Reusable/OCRView.swift
@@ -39,7 +39,11 @@ struct OCRView: View {
                 NavigationLink(destination: ItemCheckView(gptAnswer: $viewModel.gptAnswer, appState: appState), isActive: $isShowItemCheckView) {
                     EmptyView()
                 }
-                .hidden()
+//                .hidden()
+//                NavigationLink(destination: ItemCheckView(gptAnswer: $viewModel.gptAnswer, appState: appState), isActive: $isShowItemCheckView) {
+//                    EmptyView()
+//                }
+//                .hidden()
                 scanView
                   .onAppear {
                       // MARK: DispatchGroup을 enter 합니다.

--- a/SickSangHae/View/Reusable/OCRView.swift
+++ b/SickSangHae/View/Reusable/OCRView.swift
@@ -39,11 +39,6 @@ struct OCRView: View {
                 NavigationLink(destination: ItemCheckView(gptAnswer: $viewModel.gptAnswer, appState: appState), isActive: $isShowItemCheckView) {
                     EmptyView()
                 }
-//                .hidden()
-//                NavigationLink(destination: ItemCheckView(gptAnswer: $viewModel.gptAnswer, appState: appState), isActive: $isShowItemCheckView) {
-//                    EmptyView()
-//                }
-//                .hidden()
                 scanView
                   .onAppear {
                       // MARK: DispatchGroup을 enter 합니다.

--- a/SickSangHae/View/TabBarView.swift
+++ b/SickSangHae/View/TabBarView.swift
@@ -43,6 +43,7 @@ struct TabBarView: View {
             }
             .ignoresSafeArea(.keyboard)
         }
+        .environmentObject(coreDataViewModel)
     }
 }
 

--- a/SickSangHae/View/UpdateItemView.swift
+++ b/SickSangHae/View/UpdateItemView.swift
@@ -13,93 +13,99 @@ struct UpdateItemView: View {
     @ObservedObject var viewModel: UpdateItemViewModel
     @State var titleName: String
     @State var buttonName: String
+//    @State var transferDictionary: [String:[Any]] = ["상품명":[], "단가":[], "수량":[], "금액":[]]
+    @Binding var gptAnswer: [String:[Any]]
+    @State private var isItemCheckView = false
     let appState: AppState
     
     var body: some View {
-        ZStack(alignment: .top) {
-            Color.white
-                .ignoresSafeArea(.all)
-            VStack {
-                topBar
-                Spacer().frame(height: 36.adjusted)
-                DateSelectionView(viewModel: viewModel)
-                Spacer().frame(height: 30.adjusted)
-                ZStack(alignment: .top) {
-                    VStack {
-                        ScrollViewReader { proxy in
-                            ScrollView(.vertical) {
-                                VStack {
-                                    ForEach(viewModel.itemBlockViewModels, id: \.self) { item in
-                                        ItemBlockView(viewModel: viewModel, itemBlockViewModel: item)
-                                        .gesture(
-                                            DragGesture()
-                                                .onChanged({ value in
-                                                    withAnimation {
-                                                        if value.translation.width < 0 {
-                                                            item.offset = value.translation.width
-                                                        }
-                                                    }
-                                                })
-                                                .onEnded({ value in
-                                                    withAnimation {
-                                                        if value.translation.width < -90 {
-                                                            item.offset = -100
-                                                        } else {
-                                                            item.offset = 0
-                                                        }
-                                                    }
-                                                })
-                                        )
-                                    }
-                                    .onChange(of: viewModel.itemBlockViewModels) { _ in
-                                        withAnimation {
-                                            proxy.scrollTo(bottomID, anchor: .bottom)
+            ZStack(alignment: .top) {
+                Color.white
+                    .ignoresSafeArea(.all)
+                VStack {
+                    topBar
+                    Spacer().frame(height: 36.adjusted)
+                    DateSelectionView(viewModel: viewModel)
+                    Spacer().frame(height: 30.adjusted)
+                    ZStack(alignment: .top) {
+                        VStack {
+                            ScrollViewReader { proxy in
+                                ScrollView(.vertical) {
+                                    VStack {
+                                        ForEach(viewModel.itemBlockViewModels, id: \.self) { item in
+                                            ItemBlockView(viewModel: viewModel, itemBlockViewModel: item)
+                                                .gesture(
+                                                    DragGesture()
+                                                        .onChanged({ value in
+                                                            withAnimation {
+                                                                if value.translation.width < 0 {
+                                                                    item.offset = value.translation.width
+                                                                }
+                                                            }
+                                                        })
+                                                        .onEnded({ value in
+                                                            withAnimation {
+                                                                if value.translation.width < -90 {
+                                                                    item.offset = -100
+                                                                } else {
+                                                                    item.offset = 0
+                                                                }
+                                                            }
+                                                        })
+                                                )
                                         }
-                                    }
-                                    addItemButton
-                                        .onTapGesture {
+                                        .onChange(of: viewModel.itemBlockViewModels) { _ in
                                             withAnimation {
-                                                addItemBlockView()
+                                                proxy.scrollTo(bottomID, anchor: .bottom)
                                             }
                                         }
-                                        .id(bottomID)
+                                        addItemButton
+                                            .onTapGesture {
+                                                withAnimation {
+                                                    addItemBlockView()
+                                                }
+                                            }
+                                            .id(bottomID)
+                                    }
                                 }
                             }
+                            Spacer()
+                            nextButton
+                            navLink
                         }
-                        Spacer()
-                        nextButton
-                            .onTapGesture {
-                                registerItemBlockViews()
-                            }
-                    }
-                    if viewModel.isDatePickerOpen {
-                        DatePickerView(viewModel: viewModel)
+                        if viewModel.isDatePickerOpen {
+                            DatePickerView(viewModel: viewModel)
+                        }
                     }
                 }
-            }
-            
-            if viewModel.isShowTopAlertView {
-                Group {
-                    TopAlertView(viewModel: TopAlertViewModel(name: "파채", currentCase: .delete))
-                        .transition(.move(edge: .top))
-                }
-                .opacity(viewModel.isShowTopAlertView ? 1 : 0)
-                .animation(.easeInOut(duration: 0.4))
-                .onAppear {
-                    withAnimation(.easeInOut(duration: 1)) {
-                        viewModel.isShowTopAlertView = true
+                
+                if viewModel.isShowTopAlertView {
+                    Group {
+                        TopAlertView(viewModel: TopAlertViewModel(name: "파채", currentCase: .delete))
+                            .transition(.move(edge: .top))
                     }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    .opacity(viewModel.isShowTopAlertView ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.4))
+                    .onAppear {
                         withAnimation(.easeInOut(duration: 1)) {
-                            viewModel.isShowTopAlertView = false
+                            viewModel.isShowTopAlertView = true
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            withAnimation(.easeInOut(duration: 1)) {
+                                viewModel.isShowTopAlertView = false
+                            }
                         }
                     }
                 }
             }
-        }
-        .onTapGesture {
-            self.endTextEditing()
-        }
+            .onAppear {
+                for i in 0..<gptAnswer["상품명"]!.count {
+                    viewModel.makeInitialItemBlock(name: gptAnswer["상품명"]![i] as! String, price: gptAnswer["금액"]![i] as! Int)
+                }
+            }
+            .onTapGesture {
+                self.endTextEditing()
+            }
         .navigationBarBackButtonHidden(true)
     }
     
@@ -148,6 +154,8 @@ struct UpdateItemView: View {
     private var nextButton: some View {
         Button(action: {
             viewModel.isShowTextfieldWarning = !viewModel.areBothTextFieldsNotEmpty
+            registerItemBlockViews()
+            isItemCheckView = true
         }, label: {
             ZStack{
                 Rectangle()
@@ -160,6 +168,14 @@ struct UpdateItemView: View {
             .padding([.leading, .trailing], 20.adjusted)
             .padding(.bottom, 30.adjusted)
         })
+    }
+    
+    var navLink: some View {
+        NavigationLink(isActive: $isItemCheckView) {
+            ItemCheckView(gptAnswer: $gptAnswer, appState: appState)
+        } label: {
+            
+        }
     }
 }
 
@@ -233,15 +249,25 @@ extension UpdateItemView {
     }
     
     func registerItemBlockViews() {
-        for i in 0..<viewModel.itemBlockViewModels.count {
-            // TODO: CoreData 연결
+        
+        gptAnswer = ["상품명":[], "단가":[], "수량":[], "금액":[]]
+        
+        viewModel.itemBlockViewModels.forEach { item in
+            gptAnswer["상품명"]!.append(item.name)
+            gptAnswer["단가"]!.append(item.price)
+            gptAnswer["수량"]!.append(1)
+            gptAnswer["금액"]!.append(item.price)
         }
+//        for i in 0..<viewModel.itemBlockViewModels.count {
+//
+//        }
     }
 }
 
 
 struct UpdateItemView_Previews: PreviewProvider {
+    @State var testDict = ["상품명":[], "단가":[], "수량":[], "금액":[]]
   static var previews: some View {
-      UpdateItemView(viewModel: UpdateItemViewModel(), titleName: "test", buttonName: "button", appState: AppState())
+      UpdateItemView(viewModel: UpdateItemViewModel(), titleName: "test", buttonName: "button", gptAnswer: .constant(["test": []]), appState: AppState())
   }
 }

--- a/SickSangHae/View/UpdateItemView.swift
+++ b/SickSangHae/View/UpdateItemView.swift
@@ -71,7 +71,6 @@ struct UpdateItemView: View {
                             }
                             Spacer()
                             nextButton
-                            navLink
                         }
                         if viewModel.isDatePickerOpen {
                             DatePickerView(viewModel: viewModel)
@@ -155,7 +154,8 @@ struct UpdateItemView: View {
         Button(action: {
             viewModel.isShowTextfieldWarning = !viewModel.areBothTextFieldsNotEmpty
             registerItemBlockViews()
-            isItemCheckView = true
+//            isItemCheckView = true
+            dismiss()
         }, label: {
             ZStack{
                 Rectangle()
@@ -168,14 +168,6 @@ struct UpdateItemView: View {
             .padding([.leading, .trailing], 20.adjusted)
             .padding(.bottom, 30.adjusted)
         })
-    }
-    
-    var navLink: some View {
-        NavigationLink(isActive: $isItemCheckView) {
-            ItemCheckView(gptAnswer: $gptAnswer, appState: appState)
-        } label: {
-            
-        }
     }
 }
 

--- a/SickSangHae/View/UpdateItemView.swift
+++ b/SickSangHae/View/UpdateItemView.swift
@@ -13,7 +13,6 @@ struct UpdateItemView: View {
     @ObservedObject var viewModel: UpdateItemViewModel
     @State var titleName: String
     @State var buttonName: String
-//    @State var transferDictionary: [String:[Any]] = ["상품명":[], "단가":[], "수량":[], "금액":[]]
     @Binding var gptAnswer: [String:[Any]]
     @State private var isItemCheckView = false
     let appState: AppState

--- a/SickSangHae/ViewModel/OCRViewModel.swift
+++ b/SickSangHae/ViewModel/OCRViewModel.swift
@@ -123,7 +123,7 @@ class OCRViewModel: ObservableObject {
     func queryGPT(prompts: String, dispatchGroup: DispatchGroup, completion: @escaping (String) -> Void) {
         let configuration = OpenAI.Configuration(token: chatToken, organizationIdentifier: chatOrganization, timeoutInterval: 60.0)
         let openAI = OpenAI(configuration: configuration)
-        let customPrompt = prompts + "\n 이거를 딕셔너리로 정리해. 그리고 key는 상품명, 단가, 수량, 금액이야. value는 리스트형식이야. 단가, 수량, 금액에 대한 value의 list 요소들은 Int형으로 나와야 해. 딕셔너리만 응답해줘."
+        let customPrompt = prompts + "\n 이거를 딕셔너리로 정리해. 다음과 같은 포맷으로 줘야해. {\"상품명\": [], \"단가\": [], \"수량\": [], \"금액\": []}. 특수문자는 모두 제거해. 상품명에는 단가, 수량, 금액을 제거해. 단가, 수량, 금액은 Int형으로 되어있어야 해. 상품명, 단가, 수량, 금액 중에 비어 있는게 있으면 1을 추가해서 넣어. null은 모두 1로 바꿔. 그리고 상품명 value의 array size와 단가, 수량, 금액 value의 array size가 다르면 단가, 수량, 금액 value의  array size가 같아지도록 1을 추가해. 오직 딕셔너리만 응답해야 돼. 다른 말 하지마."
 
         let query = ChatQuery(model: .gpt3_5Turbo, messages: [.init(role: .user, content: customPrompt)])
         

--- a/SickSangHae/ViewModel/UpdateItemViewModel.swift
+++ b/SickSangHae/ViewModel/UpdateItemViewModel.swift
@@ -103,6 +103,10 @@ final class UpdateItemViewModel: ObservableObject {
         itemBlockViewModels.append(ItemBlockViewModel(name: "", price: 0))
     }
     
+    func makeInitialItemBlock(name: String, price: Int) {
+        itemBlockViewModels.append(ItemBlockViewModel(name: name, price: price))
+    }
+    
     
     func deleteItemBlock(itemBlockViewModel: ItemBlockViewModel) {
         for i in 0..<itemBlockViewModels.count {


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #85 

👷 **작업한 내용**
- OCR->GPT->ItemCheckView<->UpdateItemView->coredata 등록까지의 flow 를 만들었습니다

## 🚨 참고 사항
-  기존의 navigation link 로 UpdateItemView 로 넘어가는 방법이 fullScreenCover 로 바꼈습니다.
- 기존에 하나로 꼬여있던 flow 를 두개의 flow 로 나눠서 만들겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|메인화면부터 스캐닝완료까지|<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/9c167ea2-6547-4452-a71a-e9d69fd18c9b.gif">
|데이터 수정 과정|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/5e8cd545-2eb5-4697-8e79-87fd950d902a.gif">
|데이터 core data 에 저장| <img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/69a356c9-565a-4410-8310-6212669a2b1b.gif">


## 📟 관련 이슈
- Resolved: #74 
