### PR TITLE
#12/history view date grouping

### DIFF
--- a/SickSangHae/Global/Extensions/Date+Extension.swift
+++ b/SickSangHae/Global/Extensions/Date+Extension.swift
@@ -19,8 +19,8 @@ extension Date {
     }
     
     var remainingDate: String {
-        let threeMonthInSeconds = 7716600
-        let dateDifference = Calendar.current.dateComponents([.day], from: self, to: self + TimeInterval(threeMonthInSeconds)).day
+        let threeMonthInSeconds = 7889400
+        let dateDifference = Calendar.current.dateComponents([.day], from: .now, to: self + TimeInterval(threeMonthInSeconds)).day
         return String(dateDifference ?? 90)
     }
 }

--- a/SickSangHae/Global/Extensions/Date+Extension.swift
+++ b/SickSangHae/Global/Extensions/Date+Extension.swift
@@ -19,8 +19,9 @@ extension Date {
     }
     
     var remainingDate: String {
-        let threeMonthInSeconds = 7889400
-        let dateDifference = Calendar.current.dateComponents([.day], from: .now, to: self + TimeInterval(threeMonthInSeconds)).day
+        let dateTerm = DateComponents(day: 90)
+        let dateTermFromNow = Calendar.current.date(byAdding: dateTerm, to: .now) ?? .now
+        let dateDifference = Calendar.current.dateComponents([.day], from: self, to: dateTermFromNow).day
         return String(dateDifference ?? 90)
     }
 }

--- a/SickSangHae/Global/Extensions/Date+Extension.swift
+++ b/SickSangHae/Global/Extensions/Date+Extension.swift
@@ -17,4 +17,10 @@ extension Date {
         formatter.dateFormat = "yyyy년 MM월 dd일"
         return formatter.string(from: self)
     }
+    
+    var remainingDate: String {
+        let threeMonthInSeconds = 7716600
+        let dateDifference = Calendar.current.dateComponents([.day], from: self, to: self + TimeInterval(threeMonthInSeconds)).day
+        return String(dateDifference ?? 90)
+    }
 }

--- a/SickSangHae/View/HistoryView.swift
+++ b/SickSangHae/View/HistoryView.swift
@@ -31,16 +31,15 @@ struct HistoryView: View {
                 Spacer()
                     .frame(height: 20)
                 
-                segmentedTabButton
-                    .padding(.horizontal, 20)
-                
+//                segmentedTabButton
+//                    .padding(.horizontal, 20)
+//
                 
                 ScrollView {
                     deleteNotiMessage
                     
                     listSection
                     
-//                    listSection
                     
                 } //ScrollView닫기
                 .listStyle(.plain)

--- a/SickSangHae/View/HistoryView.swift
+++ b/SickSangHae/View/HistoryView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HistoryView: View {
     
-    @State var isMovingSegmentedTab = true
+    @State var isEatenTab = true
     
     @EnvironmentObject var coreDataViewModel: CoreDataViewModel
     
@@ -56,7 +56,7 @@ struct HistoryView: View {
                 Spacer()
                 
                 Button(action: {
-                    isMovingSegmentedTab = true
+                    isEatenTab = true
                 }, label: {
                     Text("먹었어요😋")
                         .font(.system(size: 20, weight: .bold))
@@ -66,7 +66,7 @@ struct HistoryView: View {
                 Spacer()
 
                 RoundedRectangle(cornerRadius: 1.5)
-                    .foregroundColor(isMovingSegmentedTab ? Color("PrimaryGB") : .clear)
+                    .foregroundColor(isEatenTab ? Color("PrimaryGB") : .clear)
                     .frame(width: 155, height: 3)
             } //VStack닫기
             
@@ -77,7 +77,7 @@ struct HistoryView: View {
                 Spacer()
                 
                 Button(action: {
-                    isMovingSegmentedTab = false
+                    isEatenTab = false
                 }, label: {
                     Text("상했어요🤢")
                         .font(.system(size: 20, weight: .bold))
@@ -87,7 +87,7 @@ struct HistoryView: View {
                 Spacer()
                 
                 RoundedRectangle(cornerRadius: 1.5)
-                    .foregroundColor(isMovingSegmentedTab ? .clear : Color("PrimaryGB"))
+                    .foregroundColor(isEatenTab ? .clear : Color("PrimaryGB"))
                     .frame(width: 155, height: 3)
             } //VStack닫기
         } //HStack닫기
@@ -111,8 +111,17 @@ struct HistoryView: View {
     
     
     var listSection: some View {
-        let eatenList: [String:[Receipt]] = coreDataViewModel.historyDictionary
-        let keys = Array(eatenList.keys.sorted(by: >))
+        
+        var targetDictionary: [String : [Receipt]] = [String : [Receipt]]()
+        var keys: [String] = [String]()
+        
+        if isEatenTab {
+            targetDictionary = coreDataViewModel.eatenDictionary
+            keys = Array(targetDictionary.keys.sorted(by: >))
+        } else {
+            targetDictionary = coreDataViewModel.spoiledDictionary
+            keys = Array(targetDictionary.keys.sorted(by: >))
+        }
 
         return ForEach(keys, id:\.self) { key in
             VStack {
@@ -121,28 +130,14 @@ struct HistoryView: View {
                     .frame(width: screenWidth, height: 12)
                     .background(Color("Gray100"))
                 
-                listTitle(eatenList: eatenList, key: key)
-                itemList(eatenList: eatenList, key: key)
+                listTitle(itemDictionary: targetDictionary, key: key)
+                itemList(itemDictionary: targetDictionary, key: key)
             }
         }
-//        VStack(spacing: 0) {
-//            listTitle(title: "test")
-//
-//            itemList
-//
-//            Spacer()
-//                .frame(height: 4)
-//
-//            Rectangle()
-//                .foregroundColor(.clear)
-//                .frame(width: screenWidth, height: 12)
-//                .background(Color("Gray100"))
-//
-//        } //VStack닫기
         
     } //listSection닫기
     
-    func listTitle(eatenList: [String: [Receipt]], key: String) -> some View {
+    func listTitle(itemDictionary: [String: [Receipt]], key: String) -> some View {
         HStack {
             Text(key)
                 .foregroundColor(Color("Gray900"))
@@ -150,7 +145,7 @@ struct HistoryView: View {
             
             Spacer()
             
-            Text("\(eatenList[key]?.first?.dateOfPurchase.remainingDate ?? "90")일 남음")
+            Text("\(itemDictionary[key]?.first?.dateOfPurchase.remainingDate ?? "90")일 남음")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(Color("Gray600"))
             
@@ -160,8 +155,8 @@ struct HistoryView: View {
         
     } //listTitle닫기
     
-    func itemList(eatenList: [String: [Receipt]], key: String) -> AnyView {
-        guard let itemList = eatenList[key] else { return AnyView(EmptyView()) }
+    func itemList(itemDictionary: [String: [Receipt]], key: String) -> AnyView {
+        guard let itemList = itemDictionary[key] else { return AnyView(EmptyView()) }
         
         return AnyView(
             ForEach(itemList, id:\.self) { item in
@@ -188,14 +183,6 @@ struct HistoryView: View {
                         }, label: {
                             Text("복구하기")
                             Image(systemName: "arrow.counterclockwise")
-                        })
-
-                        Button(action: {
-                            //아이템 상태 변경 로직
-                            isMovingSegmentedTab ? coreDataViewModel.updateStatus(target: item, to: .Spoiled) : coreDataViewModel.updateStatus(target: item, to: .Eaten)
-                        }, label: {
-                            Text(isMovingSegmentedTab ? "상했어요" : "먹었어요")
-                            Image(systemName: "arrow.triangle.2.circlepath")
                         })
 
                         Divider()

--- a/SickSangHae/View/HistoryView.swift
+++ b/SickSangHae/View/HistoryView.swift
@@ -31,8 +31,8 @@ struct HistoryView: View {
                 Spacer()
                     .frame(height: 20)
                 
-//                segmentedTabButton
-//                    .padding(.horizontal, 20)
+                segmentedTabButton
+                    .padding(.horizontal, 20)
 //
                 
                 ScrollView {
@@ -116,13 +116,13 @@ struct HistoryView: View {
 
         return ForEach(keys, id:\.self) { key in
             VStack {
-                listTitle(eatenList: eatenList, key: key)
-                itemList(eatenList: eatenList, key: key)
-                
                 Rectangle()
                     .foregroundColor(.clear)
                     .frame(width: screenWidth, height: 12)
                     .background(Color("Gray100"))
+                
+                listTitle(eatenList: eatenList, key: key)
+                itemList(eatenList: eatenList, key: key)
             }
         }
 //        VStack(spacing: 0) {
@@ -150,7 +150,7 @@ struct HistoryView: View {
             
             Spacer()
             
-            Text("\(eatenList[key]?.first?.dateOfHistory.remainingDate ?? "90")일 남음")
+            Text("\(eatenList[key]?.first?.dateOfPurchase.remainingDate ?? "90")일 남음")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(Color("Gray600"))
             

--- a/SickSangHae/View/HistoryView.swift
+++ b/SickSangHae/View/HistoryView.swift
@@ -111,43 +111,60 @@ struct HistoryView: View {
     
     
     var listSection: some View {
-        VStack(spacing: 0) {
-            listTitle
-            
-            itemList
-            
-            Spacer()
-                .frame(height: 4)
-            
-            Rectangle()
-                .foregroundColor(.clear)
-                .frame(width: screenWidth, height: 12)
-                .background(Color("Gray100"))
-            
-        } //VStack닫기
+        let eatenList: [String:[Receipt]] = coreDataViewModel.historyDictionary
+        let keys = Array(eatenList.keys.sorted(by: >))
+
+        return ForEach(keys, id:\.self) { key in
+            VStack {
+                listTitle(eatenList: eatenList, key: key)
+                itemList(eatenList: eatenList, key: key)
+                
+                Rectangle()
+                    .foregroundColor(.clear)
+                    .frame(width: screenWidth, height: 12)
+                    .background(Color("Gray100"))
+            }
+        }
+//        VStack(spacing: 0) {
+//            listTitle(title: "test")
+//
+//            itemList
+//
+//            Spacer()
+//                .frame(height: 4)
+//
+//            Rectangle()
+//                .foregroundColor(.clear)
+//                .frame(width: screenWidth, height: 12)
+//                .background(Color("Gray100"))
+//
+//        } //VStack닫기
         
     } //listSection닫기
     
-    var listTitle: some View {
+    func listTitle(eatenList: [String: [Receipt]], key: String) -> some View {
         HStack {
-            Text("2023년 7월 21일")
+            Text(key)
                 .foregroundColor(Color("Gray900"))
                 .font(.system(size: 20).weight(.semibold))
             
             Spacer()
             
-            Text("88일 남음")
+            Text("\(eatenList[key]?.first?.dateOfHistory.remainingDate ?? "90")일 남음")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(Color("Gray600"))
             
         } //HStack닫기
-        .padding([.top, .bottom], 17)
-        .padding([.leading, .trailing], 20)
+        .padding(.vertical, 17)
+        .padding(.horizontal, 20)
         
     } //listTitle닫기
     
-    var itemList: some View {
-        ForEach(isMovingSegmentedTab ? coreDataViewModel.eatenList : coreDataViewModel.spoiledList, id:\.self) { item in
+    func itemList(eatenList: [String: [Receipt]], key: String) -> AnyView {
+        guard let itemList = eatenList[key] else { return AnyView(EmptyView()) }
+        
+        return AnyView(
+            ForEach(itemList, id:\.self) { item in
             VStack {
                 HStack {
                     Image(item.icon)
@@ -172,7 +189,7 @@ struct HistoryView: View {
                             Text("복구하기")
                             Image(systemName: "arrow.counterclockwise")
                         })
-                        
+
                         Button(action: {
                             //아이템 상태 변경 로직
                             isMovingSegmentedTab ? coreDataViewModel.updateStatus(target: item, to: .Spoiled) : coreDataViewModel.updateStatus(target: item, to: .Eaten)
@@ -180,9 +197,9 @@ struct HistoryView: View {
                             Text(isMovingSegmentedTab ? "상했어요" : "먹었어요")
                             Image(systemName: "arrow.triangle.2.circlepath")
                         })
-                        
+
                         Divider()
-                        
+
                         Button(role: .destructive, action: {
                             coreDataViewModel.deleteReceiptData(target: item)
                         }, label: {
@@ -200,20 +217,19 @@ struct HistoryView: View {
                                     .frame(width: 21, height: 5)
                             )
                             .padding(.trailing, 20)
-                    } //Menu닫기
-                    
+                    }//Menu닫기
+                    .padding(.top, 12)
+
+                    Divider()
+                        .overlay(Color("Gray100"))
+                        .opacity(item == itemList.last ? 0 : 1)
+
                 } //HStack닫기
-                .padding(.top, 12)
-                
-                Divider()
-                    .overlay(Color("Gray100"))
-                    .opacity(item == coreDataViewModel.eatenList.last ? 0 : 1)
-                
+                .padding(.leading, 20)
             } //VStack닫기
-            .padding(.leading, 20)
-            
         } //ForEach닫기
-        
+        )
+
     } //itemList닫기
     
 } //struct닫기

--- a/SickSangHae/ViewModel/CoreDataViewModel.swift
+++ b/SickSangHae/ViewModel/CoreDataViewModel.swift
@@ -30,7 +30,7 @@ class CoreDataViewModel: ObservableObject {
         
         
         eatenList.forEach { item in
-            let updatedDate = item.dateOfHistory.formattedDate
+            let updatedDate = item.dateOfPurchase.formattedDate
             if let _ = dateGroupDictionary[updatedDate] {
                 dateGroupDictionary[updatedDate]!.append(item)
             } else {

--- a/SickSangHae/ViewModel/CoreDataViewModel.swift
+++ b/SickSangHae/ViewModel/CoreDataViewModel.swift
@@ -24,17 +24,28 @@ class CoreDataViewModel: ObservableObject {
         return receipts.filter{ $0.currentStatus == .longTermUnEaten}
     }
     
-    var eatenList: [Receipt] {
-        return receipts
-            .filter{ $0.currentStatus == .Eaten }
-            .sorted{ $0.dateOfHistory > $1.dateOfHistory }
+    var historyDictionary: [String : [Receipt]] {
+        let eatenList: [Receipt] = receipts.filter { $0.currentStatus == .Eaten || $0.currentStatus == .Spoiled }
+        var dateGroupDictionary: [String : [Receipt]] = [String : [Receipt]]()
+        
+        
+        eatenList.forEach { item in
+            let updatedDate = item.dateOfHistory.formattedDate
+            if let _ = dateGroupDictionary[updatedDate] {
+                dateGroupDictionary[updatedDate]!.append(item)
+            } else {
+                dateGroupDictionary[updatedDate] = [item]
+            }
+        }
+        return dateGroupDictionary
     }
     
-    var spoiledList: [Receipt] {
-        return receipts
-            .filter{ $0.currentStatus == .Spoiled }
-            .sorted{ $0.dateOfHistory > $1.dateOfHistory }
-    }
+//  MARK: 먹은것과 상한것 구분을 안한다고 해서 일단은 주석처리 해놨음
+//    var spoiledList: [Receipt] {
+//        return receipts
+//            .filter{ $0.currentStatus == .Spoiled }
+//            .sorted{ $0.dateOfHistory > $1.dateOfHistory }
+//    }
     
     init() {
         getAllReceiptData()

--- a/SickSangHae/ViewModel/CoreDataViewModel.swift
+++ b/SickSangHae/ViewModel/CoreDataViewModel.swift
@@ -24,13 +24,29 @@ class CoreDataViewModel: ObservableObject {
         return receipts.filter{ $0.currentStatus == .longTermUnEaten}
     }
     
-    var historyDictionary: [String : [Receipt]] {
-        let eatenList: [Receipt] = receipts.filter { $0.currentStatus == .Eaten || $0.currentStatus == .Spoiled }
+    var eatenDictionary: [String : [Receipt]] {
+        let eatenList: [Receipt] = receipts.filter { $0.currentStatus == .Eaten }
         var dateGroupDictionary: [String : [Receipt]] = [String : [Receipt]]()
         
         
         eatenList.forEach { item in
-            let updatedDate = item.dateOfPurchase.formattedDate
+            let updatedDate = item.dateOfHistory.formattedDate
+            if let _ = dateGroupDictionary[updatedDate] {
+                dateGroupDictionary[updatedDate]!.append(item)
+            } else {
+                dateGroupDictionary[updatedDate] = [item]
+            }
+        }
+        return dateGroupDictionary
+    }
+    
+    var spoiledDictionary: [String : [Receipt]] {
+        let spoiledList: [Receipt] = receipts.filter { $0.currentStatus == .Spoiled }
+        var dateGroupDictionary: [String : [Receipt]] = [String : [Receipt]]()
+        
+        
+        spoiledList.forEach { item in
+            let updatedDate = item.dateOfHistory.formattedDate
             if let _ = dateGroupDictionary[updatedDate] {
                 dateGroupDictionary[updatedDate]!.append(item)
             } else {


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #90 

👷 **작업한 내용**
- HistoryView 에 날짜별로 그룹핑한 먹음, 상함 데이터를 주입했습니다.
- Menu 버튼에서 상함<->먹음 버튼을 제거하였습니다.
- CoreDataViewModel 에 날짜를 key, Receipt 를 value 로 받는 EatenDictionary 와 SpoiledDictionary 를 생성하였습니다
- Date+Extension 에 90일 중에 몇일 남았는지 계산하는 로직을 넣었습니다

## 🚨 참고 사항
- 아래의 'Menu Button' 에서 복구 및 삭제 확인 항목에서 버튼 주위로 생기는 이상한 테두리는 실제로는 없음

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|먹음 선택 -> HistoryView 확인|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/a76826b5-971a-45fa-a451-385b7a65c8e1.gif">
|상함 선택 -> HistoryView 확인|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/41ed8e3e-6796-484e-b5e3-ac77e05cdaa5.gif">
|Menu 버튼에서 복구 및 삭제 확인|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/2a3d8068-6e52-4147-b9ba-d42adc6a7b3e.gif">

## 📟 관련 이슈
- Resolved: #90 
