### PR TITLE
bugfix: fix navigation bug in real iPhone

### DIFF
--- a/SickSangHae/View/OCRItemCheckView.swift
+++ b/SickSangHae/View/OCRItemCheckView.swift
@@ -57,7 +57,17 @@ struct OCRItemCheckView: View {
                     }
                     
                     Spacer()
-                    NavigationLink(destination: RegisterCompleteView(appState: appState) ,label: {
+                    
+                    NavigationLink(isActive: $isRegisterCompleteView) {
+                        RegisterCompleteView(appState: appState)
+                    } label: {
+                        EmptyView()
+                    }
+                    
+                    Button {
+                        registerItemsToCoreData()
+                        isRegisterCompleteView = true
+                    } label: {
                         ZStack {
                             Rectangle()
                                 .frame(width: 350, height: 60)
@@ -70,10 +80,7 @@ struct OCRItemCheckView: View {
                             }
                         }
                         .padding(.bottom, 30)
-                        .onTapGesture {
-                            registerItemsToCoreData()
-                        }
-                    })
+                    }
                 }
             }
             .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #102 

👷 **작업한 내용**
- NavigaionLink 오류로 인해 MainView 로 안돌아가는 로직 수정했습니다
- NavigaionLink 에 label 을 달지 않고, button 에 state 변수를 변경시켜 NavigationLink 의 isActive 를 바꾸는 로직과 coredata 에 저장하는 로직을 둘 다 넣었습니다.
- 기존에 ocr 로 가는거는 RegisterCompleteView 로 가는게 안됐는데, 이제는 그것도 가능합니다(실기기)

## 🚨 참고 사항
- appState 로 RegisterCompleteView 에서 빠져나옵니다

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "">
||<img src = "">

## 📟 관련 이슈
- Resolved: #102 
