### PR TITLE
#105/item detail view bug fix

### DIFF
--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -125,6 +125,7 @@ struct ItemDetailView: View {
                 EditItemDetailView(isShowingEditView: $isShowingEditView, iconText: receipt.icon, nameText: receipt.name, dateText: receipt.dateOfPurchase, wonText: "\(receipt.price)", appState: appState, receipt: receipt)
             }
         } //HStack닫기
+        .background(.clear)
         .padding(.top, 30)
         .padding(.horizontal, 20)
     }
@@ -140,6 +141,7 @@ struct ItemDetailView: View {
             Text("\(receipt.name)")
                 .font(.system(size: 22, weight: .bold))
         }
+        .padding(.horizontal, 20.adjusted)
     }
     
     var radioButtonGroup: some View {

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -37,11 +37,6 @@ struct ItemDetailView: View {
     
     var body: some View {
         ZStack {
-            VStack {
-                topNaviBar(dismiss: dismiss)
-                Spacer()
-            }
-            
             VStack(spacing: 0) {
                 ScrollView {
                     itemInfoSection
@@ -75,6 +70,11 @@ struct ItemDetailView: View {
                 }
             } // VStack닫기
             .padding(.top, 40)
+            
+            VStack {
+                topNaviBar(dismiss: dismiss)
+                Spacer()
+            }
                 
                 
                 VStack {
@@ -119,13 +119,13 @@ struct ItemDetailView: View {
             }
 
             Spacer()
+//                .background(.clear)
 
             menuButton
             .fullScreenCover(isPresented: $isShowingEditView) {
                 EditItemDetailView(isShowingEditView: $isShowingEditView, iconText: receipt.icon, nameText: receipt.name, dateText: receipt.dateOfPurchase, wonText: "\(receipt.price)", appState: appState, receipt: receipt)
             }
         } //HStack닫기
-        .background(.clear)
         .padding(.top, 30)
         .padding(.horizontal, 20)
     }

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -37,61 +37,67 @@ struct ItemDetailView: View {
     
     var body: some View {
         ZStack {
-            VStack(spacing: 0) {
-                topNaviBar(dismiss: dismiss)
-                
-                itemInfoSection
-                
-                SmallButtonView(receipt: receipt)
-                
-                Rectangle()
-                    .frame(width: screenWidth ,height: 12)
-                    .foregroundColor(Color("Gray100"))
-                    .padding(.top, 10)
-                    .padding(.bottom, 30)
-                
-                
-                
-                VStack(alignment: .leading) {
-                    Text("냉장고")
-                        .font(.system(size: 17, weight: .bold))
-                        .padding(.bottom, 5)
-                    
-                    radioButtonGroup
-                        .disabled(isShowingTopAlertView)
-                    
-                    Text("식료품 정보")
-                        .font(.system(size: 17, weight: .bold))
-                        .padding(.vertical, 5)
-                    
-                    itemInfoView
-                } //VStack닫기
-                .padding(.horizontal, 20.adjusted)
-                .padding(.bottom, 40)
-            } // VStack닫기
-            
-            
             VStack {
-                if isShowingTopAlertView {
-                    itemDetailTopAlertView
-                        .padding(.vertical, 30)
-                }
+                topNaviBar(dismiss: dismiss)
                 Spacer()
             }
-            CenterAlertView(titleMessage: "식료품 삭제", bodyMessage: receipt.name, actionButtonMessage: "삭제", isShowingCenterAlertView: $isShowingCenterAlertView, isDeletingItem: $isDeletingItem)
-                .opacity(isShowingCenterAlertView ? 1 : 0)
-                .onChange(of: isDeletingItem) { _ in
-                    if isDeletingItem {
-                        dismiss()
-                        coreDataViewModel.deleteReceiptData(target: receipt)
+            
+            VStack(spacing: 0) {
+                ScrollView {
+                    itemInfoSection
+                    
+                    SmallButtonView(receipt: receipt)
+                    
+                    Rectangle()
+                        .frame(width: screenWidth ,height: 12)
+                        .foregroundColor(Color("Gray100"))
+                        .padding(.top, 10)
+                        .padding(.bottom, 30)
+                    
+                    
+                    
+                    VStack(alignment: .leading) {
+                        Text("냉장고")
+                            .font(.system(size: 17, weight: .bold))
+                            .padding(.bottom, 5)
+                        
+                        radioButtonGroup
+                            .disabled(isShowingTopAlertView)
+                        
+                        Text("식료품 정보")
+                            .font(.system(size: 17, weight: .bold))
+                            .padding(.vertical, 5)
+                        
+                        itemInfoView
+                    } //VStack닫기
+                    .padding(.horizontal, 20.adjusted)
+                    .padding(.bottom, 40)
+                }
+            } // VStack닫기
+            .padding(.top, 40)
+                
+                
+                VStack {
+                    if isShowingTopAlertView {
+                        itemDetailTopAlertView
+                            .padding(.vertical, 30)
                     }
+                    Spacer()
                 }
-                .onAppear {
-
-                }
-                .onDisappear {
-                    isDeletingItem = false
-                }
+                CenterAlertView(titleMessage: "식료품 삭제", bodyMessage: receipt.name, actionButtonMessage: "삭제", isShowingCenterAlertView: $isShowingCenterAlertView, isDeletingItem: $isDeletingItem)
+                    .opacity(isShowingCenterAlertView ? 1 : 0)
+                    .onChange(of: isDeletingItem) { _ in
+                        if isDeletingItem {
+                            dismiss()
+                            coreDataViewModel.deleteReceiptData(target: receipt)
+                        }
+                    }
+                    .onAppear {
+                        
+                    }
+                    .onDisappear {
+                        isDeletingItem = false
+                    }
         }
         .navigationBarHidden(true)
     } //body닫기


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #105 

👷 **작업한 내용**
- ItemDetailView 의 각종 버그를 수정했습니다
- ItemDetailView 에 scroll 기능을 넣어서 너무 답답해보이지 않게 했습니다
- 위의 사항을 해결하니까 자동으로 TopAlertView 가 조금 더 아래로 내려오게 되었습니다
- 식료품 제목에만 padding 이 붙어있지 않은걸 수정했습니다
- Icon 은 변경된 상태로 잘 반영된것을 확인했습니다

## 🚨 참고 사항
- 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|ItemDetailView 스크롤 기능 추가 및 항목 제목 패딩 수정|<img width="551" alt="스크린샷 2023-08-01 오후 9 18 55" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/c1c66fc8-082e-4b76-b191-44f343f5a7ae">
|TopAlertView 위치 조정|<img width="551" alt="스크린샷 2023-08-01 오후 9 18 07" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/22471820/1274c929-a638-4307-ba30-b98cab687c65">


## 📟 관련 이슈
- Resolved: #105 