### PR TITLE
#109/DirectUpdateItemView bugfix

### DIFF
--- a/SickSangHae/View/DirectUpdateItemView.swift
+++ b/SickSangHae/View/DirectUpdateItemView.swift
@@ -61,6 +61,7 @@ struct DirectUpdateItemView: View {
                                             .onTapGesture {
                                                 withAnimation {
                                                     addItemBlockView()
+                                                    viewModel.countItemCheckView += 1
                                                 }
                                             }
                                             .id(bottomID)
@@ -69,6 +70,7 @@ struct DirectUpdateItemView: View {
                             }
                             Spacer()
                             nextButton
+                                .disabled(viewModel.countItemCheckView == 0 ? true : false)
                         }
                         if viewModel.isDatePickerOpen {
                             DatePickerView(viewModel: viewModel)
@@ -96,6 +98,7 @@ struct DirectUpdateItemView: View {
                 .font(.system(size: 17))
             Spacer()
             Button(action: {
+                viewModel.countItemCheckView -= 1
                 self.appState.moveToRootView = true
             } , label: {
                 Image(systemName: "xmark")

--- a/SickSangHae/ViewModel/UpdateItemViewModel.swift
+++ b/SickSangHae/ViewModel/UpdateItemViewModel.swift
@@ -16,6 +16,7 @@ final class UpdateItemViewModel: ObservableObject {
   @Published var priceInt: Int = 0
   @Published var priceString: String = ""
   @Published var name: String = ""
+  @Published var countItemCheckView: Int = 0
 
     @Published var itemBlockViewModels: [ItemBlockViewModel] = [ItemBlockViewModel]()
     


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #109 

👷 **작업한 내용**
- UpdateItemView 직접 추가에서 품목이 없어도 다음으로 넘어가는 문제를 해결하기

## 🚨 참고 사항
- 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/54494793/21593578-482b-462d-a398-0b8ee2468d91" width = 60%>|

## 📟 관련 이슈
- Resolved: #
