### PR TITLE
#119/fix item detail view

### DIFF
--- a/SickSangHae/Global/Extensions/View+Extension.swift
+++ b/SickSangHae/Global/Extensions/View+Extension.swift
@@ -14,3 +14,14 @@ extension View {
       to: nil, from: nil, for: nil)
   }
 }
+
+extension UINavigationController: UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -138,6 +138,7 @@ struct ItemDetailView: View {
             
             Text("\(receipt.name)")
                 .font(.system(size: 22, weight: .bold))
+                .multilineTextAlignment(.center)
         }
         .padding(.horizontal, 20.adjusted)
     }

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -31,8 +31,8 @@ struct ItemDetailView: View {
     }
 
     
-    var greenBlueGradient = Gradient(colors: [Color("PrimaryG"), Color("PrimaryB")])
-    var notSelectedGradient = Gradient(colors: [Color("Gray200"), Color("Gray200")])
+    var greenBlueGradient = Gradient(colors: [.primaryG, .primaryB])
+    var notSelectedGradient = Gradient(colors: [.gray200, .gray200])
     var clearGradient = Gradient(colors: [.clear, .clear])
     
     
@@ -48,7 +48,7 @@ struct ItemDetailView: View {
                     
                     Rectangle()
                         .frame(width: screenWidth ,height: 12)
-                        .foregroundColor(Color("Gray100"))
+                        .foregroundColor(.gray100)
                         .padding(.top, 10)
                         .padding(.bottom, 30)
                     
@@ -69,7 +69,7 @@ struct ItemDetailView: View {
                         
                         bottomItemInfoSection
                     } //VStack닫기
-                    .padding(.horizontal, 20.adjusted)
+                    .padding(.horizontal, 20)
                     .padding(.bottom, 40)
                 } // ScrollView닫기
             } // VStack닫기
@@ -115,7 +115,7 @@ struct ItemDetailView: View {
                     Image(systemName: "chevron.left")
                         .resizable()
                         .frame(width: 12, height: 21)
-                        .foregroundColor(Color("PrimaryGB"))
+                        .foregroundColor(.primaryGB)
                 }
             }
 
@@ -172,7 +172,7 @@ struct ItemDetailView: View {
                     .frame(width: 44, height: 44)
                 Image(systemName: "ellipsis")
                     .resizable()
-                    .foregroundColor(Color("PrimaryGB"))
+                    .foregroundColor(.primaryGB)
                     .frame(width: 22, height: 5)
             }
         } //Menu닫기
@@ -182,7 +182,7 @@ struct ItemDetailView: View {
         VStack(spacing: 0) {
             Image(receipt.icon)
                 .resizable()
-                .foregroundColor(Color("Gray200"))
+                .foregroundColor(.gray200)
                 .frame(width: 110, height: 110)
                 .padding(.vertical, 30)
             
@@ -190,7 +190,7 @@ struct ItemDetailView: View {
                 .font(.system(size: 22, weight: .bold))
                 .multilineTextAlignment(.center)
         }
-        .padding(.horizontal, 20.adjusted)
+        .padding(.horizontal, 20)
     }
     
     var radioButtonGroup: some View {
@@ -208,7 +208,7 @@ struct ItemDetailView: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
                     .frame(height: 60)
-                    .foregroundColor(Color("Gray50"))
+                    .foregroundColor(.gray50)
                 
                 HStack {
                     ZStack {
@@ -237,7 +237,7 @@ struct ItemDetailView: View {
                     Text("기본")
                         .font(.pretendard(.semiBold, size: 17))
                         .padding(.leading, 5)
-                        .foregroundColor(Color("Gray900"))
+                        .foregroundColor(.gray900)
                     
                     Spacer()
                 }
@@ -264,7 +264,7 @@ struct ItemDetailView: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
                     .frame(height: 60)
-                    .foregroundColor(Color("Gray50"))
+                    .foregroundColor(.gray50)
                 
                 HStack {
                     ZStack {
@@ -293,7 +293,7 @@ struct ItemDetailView: View {
                     Text("빨리 먹어야 해요")
                         .font(.pretendard(.semiBold, size: 17))
                         .padding(.leading, 5)
-                        .foregroundColor(Color("Gray900"))
+                        .foregroundColor(.gray900)
                     
                     Spacer()
                 }
@@ -319,7 +319,7 @@ struct ItemDetailView: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
                     .frame(height: 60)
-                    .foregroundColor(Color("Gray50"))
+                    .foregroundColor(.gray50)
                 
                 HStack {
                     ZStack {
@@ -348,7 +348,7 @@ struct ItemDetailView: View {
                     Text("천천히 먹어도 돼요")
                         .font(.pretendard(.semiBold, size: 17))
                         .padding(.leading, 5)
-                        .foregroundColor(Color("Gray900"))
+                        .foregroundColor(.gray900)
                     
                     Spacer()
                 }

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -161,14 +161,13 @@ struct ItemDetailView: View {
     
     var radioButtonGroup: some View {
         Group {
-            bacicRadioButton
+            basicRadioButton
             fastEatRadioButton
             slowEatRadioButton
         }
-        .disabled(isShowingTopAlertView)
     }
     
-    var bacicRadioButton: some View {
+    var basicRadioButton: some View {
         Button(action: {
             needToEatASAP = .shortTermUnEaten
         }, label: {

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -52,56 +52,58 @@ struct ItemDetailView: View {
                         .padding(.top, 10)
                         .padding(.bottom, 30)
                     
-                    
-                    
                     VStack(alignment: .leading) {
                         Text("냉장고")
-                            .font(.system(size: 17, weight: .bold))
+                            .font(.pretendard(.semiBold, size: 17))
+                            .foregroundColor(.gray800)
                             .padding(.bottom, 5)
                         
                         radioButtonGroup
                             .disabled(isShowingTopAlertView)
+                            .padding(.bottom, 10)
                         
                         Text("식료품 정보")
-                            .font(.system(size: 17, weight: .bold))
-                            .padding(.vertical, 5)
+                            .font(.pretendard(.semiBold, size: 17))
+                            .foregroundColor(.gray800)
+                            .padding(.bottom, 5)
                         
                         bottomItemInfoSection
                     } //VStack닫기
                     .padding(.horizontal, 20.adjusted)
                     .padding(.bottom, 40)
-                }
+                } // ScrollView닫기
             } // VStack닫기
             
             VStack {
                 if isShowingTopAlertView {
                     itemDetailTopAlertView
-                        .padding(.vertical, 30)
+                        .padding(.top, 50)
                 }
                 Spacer()
             }
-
+            
             CenterAlertView(titleMessage: "식료품 삭제", bodyMessage: receipt.name, actionButtonMessage: "삭제", isShowingCenterAlertView: $isShowingCenterAlertView, isDeletingItem: $isDeletingItem)
                 .opacity(isShowingCenterAlertView ? 1 : 0)
                 .onChange(of: isDeletingItem) { _ in
                     if isDeletingItem {
                         dismiss()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                            withAnimation(.easeOut(duration: 0.5)) {
+                            withAnimation(.easeInOut(duration: 0.2)) {
                                 coreDataViewModel.deleteReceiptData(target: receipt)
                             }
                         }
                     }
-                    Spacer()
-                }
+                } // onChange닫기
                 .onDisappear {
                     isDeletingItem = false
-                }
-        }
+                } // onDisappear닫기
+        } // ZStack닫기
         .navigationBarHidden(true)
+        
+        
     } //body닫기
         
-    func topNaviBar(dismiss: DismissAction) -> some View {
+    private func topNaviBar(dismiss: DismissAction) -> some View {
         HStack {
             Button {
                 dismiss()
@@ -109,16 +111,15 @@ struct ItemDetailView: View {
                 ZStack {
                     Rectangle()
                         .fill(.clear)
-                        .frame(width: 36, height: 36)
+                        .frame(width: 44, height: 44)
                     Image(systemName: "chevron.left")
                         .resizable()
-                        .frame(width: 10, height: 18)
-                        .foregroundColor(Color.gray600)
+                        .frame(width: 12, height: 21)
+                        .foregroundColor(Color("PrimaryGB"))
                 }
             }
 
             Spacer()
-//                .background(.clear)
 
             menuButton
             .fullScreenCover(isPresented: $isShowingEditView) {
@@ -126,7 +127,9 @@ struct ItemDetailView: View {
             }
         } //HStack닫기
         .padding(.top, 10)
-        .padding(.horizontal, 20)
+        .padding(.horizontal, 10)
+    }
+    
     private func showTopAlert(duration: TimeInterval) {
         isShowingTopAlertView = true
 
@@ -142,14 +145,45 @@ struct ItemDetailView: View {
                 showTopAlert(duration: 1.5)
             }
     }
+    
+    var menuButton: some View {
+        Menu {
+            Button(action: {
+                isShowingEditView = true
+            }, label: {
+                Text("편집")
+                Image(systemName: "pencil")
+            })
+            
+            Divider()
+            
+            Button(role: .destructive, action: {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isShowingCenterAlertView = true
+                }
+            }, label: {
+                Text("삭제")
+                Image(systemName: "trash.fill")
+            })
+        } label: {
+            ZStack {
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: 44, height: 44)
+                Image(systemName: "ellipsis")
+                    .resizable()
+                    .foregroundColor(Color("PrimaryGB"))
+                    .frame(width: 22, height: 5)
+            }
+        } //Menu닫기
     }
-        
-    var itemInfoSection: some View {
+    
+    var topItemInfoSection: some View {
         VStack(spacing: 0) {
             Image(receipt.icon)
                 .resizable()
                 .foregroundColor(Color("Gray200"))
-                .frame(width: 80, height: 80)
+                .frame(width: 110, height: 110)
                 .padding(.vertical, 30)
             
             Text("\(receipt.name)")
@@ -333,69 +367,47 @@ struct ItemDetailView: View {
         )
     }
     
-    var menuButton: some View {
-        Menu {
-            Button(action: {
-                isShowingEditView = true
-            }, label: {
-                Text("편집")
-                Image(systemName: "pencil")
-            })
-
-            Divider()
-
-            Button(role: .destructive, action: {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isShowingCenterAlertView = true
-                }
-            }, label: {
-                Text("삭제")
-                Image(systemName: "trash.fill")
-            })
-        } label: {
-            Rectangle()
-                .frame(width: 36, height: 36)
-                .foregroundColor(.clear)
-                .overlay(
-                    Image(systemName: "ellipsis")
-                        .resizable()
-                        .foregroundColor(Color.gray600)
-                        .frame(width: 21, height: 5)
-                )
-        } //Menu닫기
-    }
-    
-    
-    var itemInfoView: some View {
+    var bottomItemInfoSection: some View {
         ZStack(alignment: .trailing) {
-                Rectangle()
-                    .foregroundColor(.lightGrayColor)
-                    .cornerRadius(12)
-                
-                VStack(alignment: .leading) {
-                    HStack(spacing: 28) {
-                        Text("구매일자")
-                            .padding(.leading,20)
-                        
-                        Text("\(receipt.dateOfPurchase.formattedDate)")
-                        
-                    }
-                    Divider().foregroundColor(.gray100)
-                    HStack(spacing: 28) {
-                        Text("구매금액")
-                            .padding(.leading,20)
-                        
-                        Text("\(Int(receipt.price))")
-                        
-                    }
-                    Spacer().frame(height: 10)
+            Rectangle()
+                .foregroundColor(.gray50)
+                .cornerRadius(8)
+            
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 28) {
+                    Text("구매일자")
+                        .font(.pretendard(.medium, size: 17))
+                        .foregroundColor(.gray600)
+                        .padding(.leading,20)
+                    
+                    Text("\(receipt.dateOfPurchase.formattedDate)")
+                        .font(.pretendard(.semiBold, size: 17))
+                    
                 }
-                .frame(height: 116.adjusted)
+                
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundColor(.gray100)
+                    .padding(.leading, 20)
+                    .padding(.vertical, 16)
+                
+                HStack(spacing: 28) {
+                    Text("구매금액")
+                        .font(.pretendard(.medium, size: 17))
+                        .foregroundColor(.gray600)
+                        .padding(.leading,20)
+                    
+                    Text("\(Int(receipt.price))원")
+                        .font(.pretendard(.semiBold, size: 17))
+                    
+                }
+            }
+            .frame(height: 116.adjusted)
         }
         .padding(.bottom, 30)
     }
 }
-        
+
 struct ItemDetailView_Previews: PreviewProvider {
     static let coreDataViewModel = CoreDataViewModel()
     static var previews: some View {

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -127,6 +127,21 @@ struct ItemDetailView: View {
         } //HStack닫기
         .padding(.top, 10)
         .padding(.horizontal, 20)
+    private func showTopAlert(duration: TimeInterval) {
+        isShowingTopAlertView = true
+
+        timer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { _ in
+            isShowingTopAlertView = false
+        }
+    }
+
+    var itemDetailTopAlertView: some View {
+        TopAlertView(viewModel: topAlertViewModel)
+            .opacity(isShowingTopAlertView ? 1 : 0)
+            .onAppear {
+                showTopAlert(duration: 1.5)
+            }
+    }
     }
         
     var itemInfoSection: some View {

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -40,9 +40,9 @@ struct ItemDetailView: View {
         ZStack {
             VStack(spacing: 0) {
                 topNaviBar(dismiss: dismiss)
+                
                 ScrollView {
-                    
-                    itemInfoSection
+                    topItemInfoSection
                     
                     SmallButtonView(receipt: receipt)
                     
@@ -66,7 +66,7 @@ struct ItemDetailView: View {
                             .font(.system(size: 17, weight: .bold))
                             .padding(.vertical, 5)
                         
-                        itemInfoView
+                        bottomItemInfoSection
                     } //VStack닫기
                     .padding(.horizontal, 20.adjusted)
                     .padding(.bottom, 40)

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -17,6 +17,7 @@ struct ItemDetailView: View {
     @State private var isShowingTopAlertView = false
     @State private var isShowingCenterAlertView = false
     @State private var isDeletingItem = false
+    @State private var timer: Timer? = nil
     @State var receipt: Receipt
     @State var appState: AppState
     @State var needToEatASAP: Status {

--- a/SickSangHae/View/ItemDetailView.swift
+++ b/SickSangHae/View/ItemDetailView.swift
@@ -378,66 +378,7 @@ struct ItemDetailView: View {
                 }
                 .frame(height: 116.adjusted)
         }
-    }
-    
-    var itemDetailTopAlertView: some View {
-        Group {
-            TopAlertView(viewModel: topAlertViewModel)
-                .transition(.move(edge: .top))
-        }
-        .opacity(isShowingTopAlertView ? 1 : 0)
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    isShowingTopAlertView = false
-            }
-        }
-    }
-}
-
-struct ItemDetailTopAlertView: View {
-    let name: String
-    var body: some View {
-        ItemDetailTopAlertBaseView(iconImage: "img_eat", message: "\(name) 항목이 일반으로 이동됐어요", backgroundColor: .pointRLight, strokeColor: .pointRMiddle)
-    }
-}
-
-struct ItemDetailTopAlertBaseView: View {
-  var iconImage: String
-  var message: String
-  var backgroundColor: Color
-  var strokeColor: Color
-  @GestureState private var dragOffset = CGSize.zero
-  
-
-  var body: some View {
-      ZStack(alignment: .leading) {
-        RoundedRectangle(cornerRadius: 41.adjusted)
-          .stroke(strokeColor, lineWidth: 1)
-          .background(backgroundColor)
-          .background(.ultraThickMaterial)
-          .frame(height: 68.adjusted)
-          .clipShape(RoundedRectangle(cornerRadius: 41.adjusted))
-          .opacity(0.8)
-        HStack(spacing: 10.adjusted) {
-          Image(iconImage)
-            .resizable()
-            .scaledToFill()
-            .frame(width: 44.adjusted, height: 44.adjusted)
-          VStack(alignment: .leading, spacing: 4.adjusted) {
-            Text(message)
-              .font(.system(size: 14).bold())
-              .foregroundColor(.black)
-          }
-        }
-        .padding(.leading, 14.adjusted)
-      }
-      .padding([.leading, .trailing], 20.adjusted)
-  }
-}
-
-extension ItemDetailTopAlertView: Hashable {
-    func hash(into hasher: inout Hasher) {
-        
+        .padding(.bottom, 30)
     }
 }
         

--- a/SickSangHae/View/Reusable/BasicList.swift
+++ b/SickSangHae/View/Reusable/BasicList.swift
@@ -130,6 +130,7 @@ private struct ListContent: View {
                     Text(item.name)
                         .font(.system(size: 17).weight(.semibold))
                         .foregroundColor(Color("Gray900"))
+                        .frame(height: 17)
                     
                     Spacer()
                     

--- a/SickSangHae/View/Reusable/LongTermList.swift
+++ b/SickSangHae/View/Reusable/LongTermList.swift
@@ -93,6 +93,7 @@ Array(zip(listContentViewModel.itemList.indices, listContentViewModel.itemList.r
                         Text(item.name)
                             .font(.system(size: 17).weight(.semibold))
                             .foregroundColor(Color("Gray900"))
+                            .frame(height: 17)
                         
                         Spacer()
                         

--- a/SickSangHae/View/Reusable/SmallButtonView.swift
+++ b/SickSangHae/View/Reusable/SmallButtonView.swift
@@ -29,7 +29,7 @@ struct SmallButtonView: View {
                             Rectangle()
                                 .stroke(lineWidth: 0)
                                 .background(Color("PrimaryG"))
-                                .cornerRadius(15)
+                                .cornerRadius(16)
                             Text("먹었어요😋")
                         }
                     }
@@ -50,14 +50,13 @@ struct SmallButtonView: View {
                             Rectangle()
                                 .stroke(lineWidth: 0)
                                 .background(Color("SmallButton"))
-                                .cornerRadius(15)
+                                .cornerRadius(16)
                             Text("상했어요🤢")
                         }
                     }
                     .buttonStyle(CustomButtonStyle())
                 }
-                .padding(EdgeInsets(top: 20.adjusted, leading: 20.adjusted, bottom: 20.adjusted, trailing: 20.adjusted))
-                // Figma 화면과 비슷한 배율로 그리려면 top padding 15로 해야함
+                .padding(EdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20))
             }
         }
     }
@@ -66,7 +65,7 @@ struct SmallButtonView: View {
         func makeBody(configuration: Configuration) -> some View {
             configuration.label
                 .fontWeight(.heavy)
-                .frame(width: 167.adjusted, height: 60.adjusted)
+                .frame(width: 167.adjusted, height: 55)
                 .foregroundColor(.white)
                 .opacity(configuration.isPressed ? 0.7 : 1)
         }

--- a/SickSangHae/View/Reusable/TopAlertView.swift
+++ b/SickSangHae/View/Reusable/TopAlertView.swift
@@ -27,48 +27,48 @@ struct TopAlertView: View {
 }
 
 struct TopAlertBaseView: View {
-  var iconImage: String
-  var message: String
-  var backgroundColor: Color
-  var strokeColor: Color
-  @GestureState private var dragOffset = CGSize.zero
-  @ObservedObject var viewModel: TopAlertViewModel
+    var iconImage: String
+    var message: String
+    var backgroundColor: Color
+    var strokeColor: Color
+    //  @GestureState private var dragOffset = CGSize.zero
+    @ObservedObject var viewModel: TopAlertViewModel
 
-  var body: some View {
-    if viewModel.isAlertVisible {
-      ZStack(alignment: .leading) {
-        RoundedRectangle(cornerRadius: 41.adjusted)
-          .stroke(strokeColor, lineWidth: 1)
-          .background(Color.gray100)
-          .background(.ultraThickMaterial)
-          .frame(height: 68.adjusted)
-          .clipShape(RoundedRectangle(cornerRadius: 41.adjusted))
-          .opacity(0.8)
-        HStack(spacing: 10.adjusted) {
-            Image(systemName: "checkmark.circle.fill")
-            .resizable()
-            .foregroundColor(.primaryGB)
-            .scaledToFill()
-            .frame(width: 44.adjusted, height: 44.adjusted)
-          VStack(alignment: .leading, spacing: 4.adjusted) {
-            Text(message)
-                  .font(.pretendard(.bold, size: 14))
-              .foregroundColor(.black)
-          }
+    var body: some View {
+        if viewModel.isAlertVisible {
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 34)
+                    .stroke(strokeColor, lineWidth: 2)
+                    .background(Color.alertGreen)
+                    .frame(height: 68)
+                    .clipShape(RoundedRectangle(cornerRadius: 34))
+                HStack(spacing: 10) {
+                    ZStack {
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 40, height: 40)
+                        Image(systemName: "checkmark.circle.fill")
+                            .resizable()
+                            .foregroundColor(.primaryGB)
+                            .frame(width: 40, height: 40)
+                    }
+                    Text(message)
+                        .font(.pretendard(.bold, size: 14))
+                        .foregroundColor(.gray800)
+                        .padding(.leading, 10)
+                }
+                .padding(.horizontal, 14)
+            }
+            .padding(.horizontal, 20)
+//            .offset(y: max(dragOffset.height, 0))
+//            .gesture (DragGesture()
+//                .updating($dragOffset, body: { (value, dragOffset, _) in
+//                    dragOffset = value.translation
+//                })
+//                    .onEnded(viewModel.onDragEnded)
+//            )
         }
-        .padding(.leading, 14.adjusted)
-      }
-      .padding([.leading, .trailing], 20.adjusted)
-      .offset(y: max(dragOffset.height, 0))
-      .gesture (DragGesture()
-        .updating($dragOffset, body: { (value, dragOffset, _) in
-           dragOffset = value.translation
-         })
-          .onEnded(viewModel.onDragEnded)
-                
-      )
     }
-  }
 }
 
 struct TopAlertView_Previews: PreviewProvider {

--- a/SickSangHae/View/Reusable/TopAlertView.swift
+++ b/SickSangHae/View/Reusable/TopAlertView.swift
@@ -34,6 +34,8 @@ struct TopAlertBaseView: View {
     //  @GestureState private var dragOffset = CGSize.zero
     @ObservedObject var viewModel: TopAlertViewModel
 
+    // TODO: TopAlert의 애니메이션 이슈가 해결되면 드래그 기능을 다시 활용
+
     var body: some View {
         if viewModel.isAlertVisible {
             ZStack(alignment: .leading) {
@@ -60,13 +62,6 @@ struct TopAlertBaseView: View {
                 .padding(.horizontal, 14)
             }
             .padding(.horizontal, 20)
-//            .offset(y: max(dragOffset.height, 0))
-//            .gesture (DragGesture()
-//                .updating($dragOffset, body: { (value, dragOffset, _) in
-//                    dragOffset = value.translation
-//                })
-//                    .onEnded(viewModel.onDragEnded)
-//            )
         }
     }
 }

--- a/SickSangHae/View/Reusable/TopAlertView.swift
+++ b/SickSangHae/View/Reusable/TopAlertView.swift
@@ -10,19 +10,19 @@ import SwiftUI
 //MARK: - 색, 폰트 변경
 
 struct TopAlertView: View {
-  @ObservedObject var viewModel: TopAlertViewModel
+    @ObservedObject var viewModel: TopAlertViewModel
     
     var body: some View {
-      switch viewModel.changedStatus {
-      case .shortTermUnEaten:
-          TopAlertBaseView(iconImage: "img_eat", message: "\"기본\" 보관으로 변경했어요", backgroundColor: .primaryGLight, strokeColor: .primaryGMiddle, viewModel: viewModel)
-      case .shortTermPinned:
-        TopAlertBaseView(iconImage: "img_eat", message: "\"빨리 먹어야 해요\" 보관으로 변경했어요", backgroundColor: .primaryGLight, strokeColor: .primaryGMiddle, viewModel: viewModel)
-      case .longTermUnEaten:
-        TopAlertBaseView(iconImage: "img_eat", message: "\"천천히 먹어도 돼요\" 보관으로 변경했어요", backgroundColor: .primaryGLight, strokeColor: .primaryGMiddle, viewModel: viewModel)
-      default:
-          TopAlertBaseView(iconImage: "img_eat", message: "\(viewModel.name) 항목이 일반으로 이동됐어요", backgroundColor: .alertGreen, strokeColor: .primaryGMiddle, viewModel: viewModel)
-      }
+        switch viewModel.changedStatus {
+        case .shortTermUnEaten:
+            TopAlertBaseView(iconImage: "img_eat", message: "\"기본\" 보관으로 변경했어요", backgroundColor: .alertGreen, strokeColor: .primaryGMiddle, viewModel: viewModel)
+        case .shortTermPinned:
+            TopAlertBaseView(iconImage: "img_eat", message: "\"빨리 먹어야 해요\" 보관으로 변경했어요", backgroundColor: .alertGreen, strokeColor: .primaryGMiddle, viewModel: viewModel)
+        case .longTermUnEaten:
+            TopAlertBaseView(iconImage: "img_eat", message: "\"천천히 먹어도 돼요\" 보관으로 변경했어요", backgroundColor: .alertGreen, strokeColor: .primaryGMiddle, viewModel: viewModel)
+        default:
+            TopAlertBaseView(iconImage: "img_eat", message: "\(viewModel.name) 항목이 일반으로 이동됐어요", backgroundColor: .alertGreen, strokeColor: .primaryGMiddle, viewModel: viewModel)
+        }
     }
 }
 


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #119 

👷 **작업한 내용**
- **ItemDetailView**
    - font refactor.
    - extension추가로 스와이프하여 뒤로가기 가능.
    - TopAlert 관련
        - Alert유지시간 로직을 DispatchQueue 대신 timer로 교체.
        - 냉장고를 반복적으로 누르면 Alert이 멈추는 문제 해결.
        - 기존 테스트에 사용되던 TopAlert 코드 삭제.
        - Alert가 뜨는 위치 조정.
    - TopNavigation 관련
        - 버튼 위치 조정.
        - 버튼 터치 영역 확대.
        - 버튼 사이즈 변경.
    - ItemInfo 관련
        - 품목명 좌측정렬되는 문제 수정.
        - ItemImage 사이즈 확대.
        - TopItemInfo와 BottomItemInfo로 섹션 이름 변경.
        - BottomItemInfo의 디자인 수정.
- **TopAlertView**
    - indent refactor.
    - switch case에서 background의 Color 변경.
    - 제스처 관련 로직 삭제.
    - adjust삭제.
    - 피그마 업데이트에 맞추어 Alert 디자인 일부 수정.
- **SmallButtonView**
    - 피그마 디자인 업데이트에 맞추어 버튼 사이즈 수정.
    - 일부 adjust삭제.
- **View+Extension**
    - 스와이프하여 뒤로가기 기능을 위한 익스텐션 추가.
- **BasicListView & LongTermListView**
    - 품목명이 여러줄이 되지 않도록 Text() height 제한.

## 🚨 참고 사항
- 많은 피드백 바랍니다.
- 현재 ItemDetailView에서 냉장고 변경시 버튼을 막 누르면 TopAlert가 멈춰버리는 문제를 해결한 것 같긴한데 나중에 봐주시면 감사하겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|ItemDetailView|![Simulator Screen Recording - iPhone 14 Pro - 2023-08-10 at 02 14 00](https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-BALANCEIAGA/assets/123388563/96cd96b5-c02f-418a-b6c2-72e887379f42)
